### PR TITLE
Don't run tools if there's an error

### DIFF
--- a/src/hooks/use-tool-executor.js
+++ b/src/hooks/use-tool-executor.js
@@ -2,14 +2,14 @@
 import { useEffect } from 'react';
 
 const useToolExecutor = ( {
-	chat: { running, pendingToolCalls, setToolResult },
+	chat: { error, running, pendingToolCalls, setToolResult },
 	toolkit: { callbacks },
 } ) => {
 	useEffect( () => {
 		// process tool calls for any tools with callbacks
 		// note that tools without callbacks will be processed outside this loop,
 		// and will need responses before the ChatModel can run again
-		if ( ! running && pendingToolCalls.length > 0 ) {
+		if ( ! error && ! running && pendingToolCalls.length > 0 ) {
 			pendingToolCalls.forEach( ( tool_call ) => {
 				if ( tool_call.inProgress ) {
 					return;

--- a/src/store/chat.js
+++ b/src/store/chat.js
@@ -384,7 +384,7 @@ function* setToolCallResult( toolCallId, promise ) {
 		return {
 			type: 'TOOL_ERROR',
 			id: toolCallId,
-			error: error.message,
+			error: error.message || 'There was an error',
 		};
 	}
 }
@@ -606,11 +606,18 @@ export const reducer = ( state = initialState, action ) => {
 					tool_call_id: action.tool_call_id,
 					content: action.result,
 				} ),
+				error: null,
 				isToolRunning: false,
 			};
 		case 'TOOL_ERROR':
 			return {
-				...state,
+				...addMessageReducer( state, {
+					role: 'tool',
+					id: action.id,
+					tool_call_id: action.tool_call_id,
+					content: 'Error',
+				} ),
+				error: action.error,
 				isToolRunning: false,
 			};
 		case 'SUBMIT_TOOL_OUTPUTS_BEGIN_REQUEST':


### PR DESCRIPTION
Previously we would just loop infinitely if requests to WPCOM APIs failed (e.g. Analyze URL missing authentication)

Now if there's an error we don't keep processing tool calls.