### PR TITLE
Fix state issues and show question when no tool calls

### DIFF
--- a/src/components/agent-ui.jsx
+++ b/src/components/agent-ui.jsx
@@ -118,7 +118,20 @@ function AgentUI( {
 						<AgentThought message={ agentThought } />
 					) }
 					{ assistantMessage && (
-						<AgentMessage message={ assistantMessage } />
+						<AgentMessage message={ assistantMessage }>
+							{ ! agentQuestion && ! agentConfirm ? (
+								<AskUserQuestion
+									onAnswer={ ( answer, files ) => {
+										userSay( answer, files );
+									} }
+									onCancel={ () => {
+										informUser( 'Canceled!' );
+										onResetTools();
+										onResetChat();
+									} }
+								/>
+							) : null }
+						</AgentMessage>
 					) }
 					{ agentQuestion && (
 						<AskUserQuestion

--- a/src/hooks/use-redux-chat.js
+++ b/src/hooks/use-redux-chat.js
@@ -420,11 +420,11 @@ const useReduxChat = ( { apiKey, service, model, temperature, feature } ) => {
 			} );
 		},
 		[
-			assistantMessage,
 			isAssistantAvailable,
 			isThreadRunComplete,
 			isAwaitingUserInput,
 			additionalMessages,
+			history.length,
 			service,
 			apiKey,
 			assistantId,


### PR DESCRIPTION
 * When there was no question or confirm, it wasn't showing text box
 * Use proper state checks for `runCreateThreadRun()` call