### PR TITLE
Move console.logs to a log util 

### DIFF
--- a/src/ai/agents/agent.js
+++ b/src/ai/agents/agent.js
@@ -1,3 +1,8 @@
+/**
+ * Internal dependencies
+ */
+import log from '../../utils/log-debug.js';
+
 import AskUserTool from '../tools/ask-user.js';
 import { DotPromptTemplate } from '../prompt-template.js';
 import InformUserTool from '../tools/inform-user.js';
@@ -31,7 +36,7 @@ class Agent {
 
 	onToolResult( toolName, value, toolResponse ) {
 		// do nothing by default
-		console.log( 'onToolResult', {
+		log.info( 'onToolResult', {
 			toolName,
 			value,
 			toolResponse,

--- a/src/ai/chat-model.js
+++ b/src/ai/chat-model.js
@@ -1,3 +1,8 @@
+/**
+ * Internal dependencies
+ */
+import log from '../utils/log-debug';
+
 // TODO: extract all this to a JSON configuration file
 export const ChatModelService = {
 	WPCOM_JETPACK_AI: 'wpcom-jetpack-ai',
@@ -293,7 +298,7 @@ class ChatModel {
 		const params = this.getParams( request );
 		const headers = this.getHeaders();
 
-		console.log(
+		log.info(
 			`🤖 Calling ${ this.constructor.name } with model ${ params.model }, temperature ${ params.temperature }, max_tokens ${ params.max_tokens }`
 		);
 

--- a/src/ai/utils/dot.js
+++ b/src/ai/utils/dot.js
@@ -1,5 +1,8 @@
 'use strict';
-
+/**
+ * Internal dependencies
+ */
+import log from '../../utils/log-debug.js';
 // Adapted from doT.js, 2011-2014, Laura Doktorova, https://github.com/olado/doT
 // Licensed under the MIT license.
 
@@ -203,7 +206,7 @@ export function compile( tmpl, def ) {
 		try {
 			return f();
 		} catch ( e ) {
-			console.log( 'Could not create a template function: ' + str );
+			log.error( 'Could not create a template function: ' + str );
 			throw e;
 		}
 	}

--- a/src/ai/utils/geocoder.js
+++ b/src/ai/utils/geocoder.js
@@ -1,4 +1,9 @@
 /**
+ * Internal dependencies
+ */
+import log from '../../utils/log-debug.js';
+
+/**
  * TODO
  */
 class Geocoder {
@@ -16,7 +21,7 @@ class Geocoder {
 
 		const data = await response.json();
 
-		console.log( 'Geocode Response', data );
+		log.info( 'Geocode Response', data );
 
 		// actually let's map a list of locations from the existing data.features array
 		const featuresResponse = data?.features?.map( ( feature ) => {

--- a/src/components/object-preview.js
+++ b/src/components/object-preview.js
@@ -7,6 +7,11 @@ import {
 	__experimentalItemGroup as ItemGroup,
 } from '@wordpress/components';
 
+/**
+ * Internal dependencies
+ */
+import log from '../utils/log-debug.js';
+
 function ObjectPreview( { object, prefix = '' } ) {
 	if ( ! object ) {
 		return (
@@ -42,7 +47,7 @@ function ObjectPreview( { object, prefix = '' } ) {
 						key={ prop }
 						className={ `big-sky__edit-site-spec-${ prefix }${ prop }` }
 						onClick={ () => {
-							console.log( `clicked ${ prop } - would edit now` );
+							log.info( `clicked ${ prop } - would edit now` );
 						} }
 					>
 						<BaseControl

--- a/src/hooks/use-chat-model.js
+++ b/src/hooks/use-chat-model.js
@@ -7,6 +7,7 @@ import { useEffect, useState } from 'react';
  * Internal dependencies
  */
 import ChatModel from '../ai/chat-model.js';
+import log from '../utils/log-debug.js';
 
 const useChatModel = ( { apiKey, service, feature, sessionId } ) => {
 	const [ chatModel, setChatModel ] = useState();
@@ -25,13 +26,7 @@ const useChatModel = ( { apiKey, service, feature, sessionId } ) => {
 			return;
 		}
 		// eslint-disable-next-line no-console
-		console.log(
-			'🤖 Creating Chat Model',
-			service,
-			apiKey,
-			feature,
-			sessionId
-		);
+		log.info( '🤖 Creating Chat Model', service, feature, sessionId );
 		setChatModel(
 			ChatModel.getInstance( service, apiKey, feature, sessionId )
 		);

--- a/src/utils/log-debug.js
+++ b/src/utils/log-debug.js
@@ -1,0 +1,9 @@
+const showLogs = true;
+// TODO: switch to the following before going to production.
+// const showLogs = process.env.DEBUG;
+
+export default {
+	info: showLogs ? console.info.bind( window.console ) : () => {},
+	warn: showLogs ? console.warn.bind( window.console ) : () => {},
+	error: showLogs ? console.error.bind( window.console ) : () => {},
+};


### PR DESCRIPTION
Just a small tidy up so we can easily toggle/redirect logging depending on env

## Testing

It shouldn't affect anything, but try running the storybook examples and check that the console logs still show and with the correct line numbers