### PR TITLE
Add createSelector and useMemo to prevent additional renders

### DIFF
--- a/src/components/chat-provider/use-chat.js
+++ b/src/components/chat-provider/use-chat.js
@@ -103,40 +103,43 @@ export default function useChat() {
 		isAwaitingUserInput,
 		isThreadRunAwaitingToolOutputs,
 		feature,
-	} = useSelect( ( select ) => {
-		const store = select( agentStore );
-		return {
-			assistantEnabled: store.isAssistantEnabled(),
-			service: store.getService(),
-			apiKey: store.getApiKey(),
-			error: store.getError(),
-			model: store.getModel(),
-			loading: store.isLoading(),
-			running: store.isRunning(),
-			enabled: store.isEnabled(),
-			messages: store.getMessages(),
-			assistantMessage: store.getAssistantMessage(),
-			pendingToolCalls: store.getPendingToolCalls(),
-			additionalMessages: store.getAdditionalMessages(),
-			requiredToolOutputs: store.getRequiredToolOutputs(),
-			toolOutputs: store.getToolOutputs(),
-			threadId: store.getThreadId(),
-			assistantId: store.getAssistantId(),
-			threadRun: store.getActiveThreadRun(),
-			threadRunsUpdated: store.getThreadRunsUpdated(),
-			threadMessagesUpdated: store.getThreadMessagesUpdated(),
-			isAvailable: store.isAvailable(),
-			isChatAvailable: store.isChatAvailable(),
-			isAssistantAvailable: store.isAssistantAvailable(),
-			isThreadRunInProgress: store.isThreadRunInProgress(),
-			isThreadDataLoaded: store.isThreadDataLoaded(),
-			isThreadRunComplete: store.isThreadRunComplete(),
-			isAwaitingUserInput: store.isAwaitingUserInput(),
-			isThreadRunAwaitingToolOutputs:
-				store.isThreadRunAwaitingToolOutputs(),
-			feature: store.getFeature(),
-		};
-	} );
+	} = useSelect(
+		( select ) => {
+			const store = select( agentStore );
+			return {
+				assistantEnabled: store.isAssistantEnabled(),
+				service: store.getService(),
+				apiKey: store.getApiKey(),
+				error: store.getError(),
+				model: store.getModel(),
+				loading: store.isLoading(),
+				running: store.isRunning(),
+				enabled: store.isEnabled(),
+				messages: store.getMessages(),
+				assistantMessage: store.getAssistantMessage(),
+				pendingToolCalls: store.getPendingToolCalls(),
+				additionalMessages: store.getAdditionalMessages(),
+				requiredToolOutputs: store.getRequiredToolOutputs(),
+				toolOutputs: store.getToolOutputs(),
+				threadId: store.getThreadId(),
+				assistantId: store.getAssistantId(),
+				threadRun: store.getActiveThreadRun(),
+				threadRunsUpdated: store.getThreadRunsUpdated(),
+				threadMessagesUpdated: store.getThreadMessagesUpdated(),
+				isAvailable: store.isAvailable(),
+				isChatAvailable: store.isChatAvailable(),
+				isAssistantAvailable: store.isAssistantAvailable(),
+				isThreadRunInProgress: store.isThreadRunInProgress(),
+				isThreadDataLoaded: store.isThreadDataLoaded(),
+				isThreadRunComplete: store.isThreadRunComplete(),
+				isAwaitingUserInput: store.isAwaitingUserInput(),
+				isThreadRunAwaitingToolOutputs:
+					store.isThreadRunAwaitingToolOutputs(),
+				feature: store.getFeature(),
+			};
+		},
+		[ agentStore ]
+	);
 
 	return {
 		// running state

--- a/src/hooks/use-site-toolkit.js
+++ b/src/hooks/use-site-toolkit.js
@@ -49,20 +49,16 @@ const useSiteToolkit = ( { pageId } ) => {
 	} = useDispatch( agentStore );
 
 	// these are fed to the templating engine on each render of the system/after-call prompt
-	const context = useSelect(
+	const siteData = useSelect(
 		( select ) => ( {
-			site: {
-				title: select( agentStore ).getSiteTitle(),
-				description: select( agentStore ).getSiteDescription(),
-				topic: select( agentStore ).getSiteTopic(),
-				type: select( agentStore ).getSiteType(),
-				location: select( agentStore ).getSiteLocation(),
-			},
-			design: {
-				textColor: select( agentStore ).getTextColor(),
-				backgroundColor: select( agentStore ).getBackgroundColor(),
-				accentColor: select( agentStore ).getAccentColor(),
-			},
+			title: select( agentStore ).getSiteTitle(),
+			description: select( agentStore ).getSiteDescription(),
+			topic: select( agentStore ).getSiteTopic(),
+			type: select( agentStore ).getSiteType(),
+			location: select( agentStore ).getSiteLocation(),
+			textColor: select( agentStore ).getTextColor(),
+			backgroundColor: select( agentStore ).getBackgroundColor(),
+			accentColor: select( agentStore ).getAccentColor(),
 			pages: select( agentStore ).getPages(),
 			pageId,
 			page: select( agentStore ).getPage( pageId ),
@@ -70,6 +66,29 @@ const useSiteToolkit = ( { pageId } ) => {
 			// pageSections: select( agentStore ).getPageSections(),
 		} ),
 		[ pageId ]
+	);
+
+	const context = useMemo(
+		() => ( {
+			site: {
+				title: siteData.title,
+				description: siteData.description,
+				topic: siteData.topic,
+				type: siteData.type,
+				location: siteData.location,
+			},
+			design: {
+				textColor: siteData.textColor,
+				backgroundColor: siteData.backgroundColor,
+				accentColor: siteData.accentColor,
+			},
+			pages: siteData.pages,
+			pageId,
+			page: siteData.page,
+			// TODO
+			// pageSections: select( agentStore ).getPageSections(),
+		} ),
+		[ siteData, pageId ]
 	);
 
 	const callbacks = useMemo( () => {


### PR DESCRIPTION
There are some store selectors that will cause additional rerenders. This PR adds `createSelector` to the store so that selectors that mutate state before returning it are memoised, and also updates the site context useSelect to return a single object which is mutated and memoised outside the selector.

## Testing
Run the storybook examples and check the console for useSelect warnings.

Before:
<img width="1131" alt="Screenshot 2024-07-10 at 2 18 47 PM" src="https://github.com/Automattic/big-sky-agents/assets/3629020/2b81c890-fe42-4d50-b8f1-3e42cee94b7f">

After
<img width="1124" alt="Screenshot 2024-07-10 at 2 18 14 PM" src="https://github.com/Automattic/big-sky-agents/assets/3629020/eda70c24-eece-46c2-b7a1-86abe207deaa">
