### PR TITLE
Register toolkits when an agent is registered

### DIFF
--- a/src/components/agents-provider/use-agent.js
+++ b/src/components/agents-provider/use-agent.js
@@ -4,8 +4,10 @@ import { Context } from './context.jsx';
 
 function useAgent( agent ) {
 	const agentStore = useContext( Context );
+	const toolkitsStore = useContext( Context );
 
 	const { registerAgent, setActiveAgent } = useDispatch( agentStore );
+	const { registerToolkit } = useDispatch( toolkitsStore );
 	const { activeAgentId } = useSelect( ( select ) => {
 		const store = select( agentStore );
 		return {
@@ -16,11 +18,21 @@ function useAgent( agent ) {
 	useEffect( () => {
 		registerAgent( agent );
 
+		for ( const toolkit of agent.toolkits || [] ) {
+			registerToolkit( toolkit );
+		}
+
 		// if there's no current agent, set it as the current agent
 		if ( ! activeAgentId ) {
 			setActiveAgent( agent.id );
 		}
-	}, [ activeAgentId, agent, registerAgent, setActiveAgent ] );
+	}, [
+		activeAgentId,
+		agent,
+		registerAgent,
+		registerToolkit,
+		setActiveAgent,
+	] );
 }
 
 export default useAgent;

--- a/src/components/toolkits-provider/use-toolkits.js
+++ b/src/components/toolkits-provider/use-toolkits.js
@@ -199,9 +199,18 @@ export default function useToolkits() {
 	const hasToolkits = useCallback(
 		( requestedToolkits ) => {
 			return requestedToolkits.every( ( requestedToolkit ) =>
-				toolkits.some(
-					( toolkit ) => toolkit.name === requestedToolkit
-				)
+				toolkits.some( ( toolkit ) => {
+					if ( typeof toolkit === 'string' ) {
+						return toolkit.name === requestedToolkit;
+					} else if (
+						typeof requestedToolkit === 'object' &&
+						requestedToolkit
+					) {
+						return toolkit.name === requestedToolkit.name;
+					}
+
+					return false;
+				} )
 			);
 		},
 		[ toolkits ]


### PR DESCRIPTION
Proposed changes to make agent and toolkit registering simpler from the client. Instead of having to registering toolkits separately from the agent, after an agent is registered it will also register any toolkits it contains.

Also this will allow adding toolkits to the agent with the toolkit object instead of the name. I think registering will still work the same in either case.

This stemmed from [this PR](https://github.com/Automattic/big-sky-agents-react/pull/8) to get the React App working with the latest agents code.