### PR TITLE
Add the ability to abort messages from ChatModel.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@automattic/big-sky-agents",
-  "version": "1.1.28",
+  "version": "1.1.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@automattic/big-sky-agents",
-      "version": "1.1.28",
+      "version": "1.1.29",
       "license": "GPL-2.0-or-later",
       "devDependencies": {
         "@babel/eslint-parser": "^7.24.7",


### PR DESCRIPTION
Use in conjunction with https://github.com/Automattic/big-sky-plugin/pull/1481

This adds an AbortController to the ChatModel class so that requests can be aborted.
See https://github.com/Automattic/big-sky-plugin/issues/1460 for designs and specs.