### PR TITLE
Try storing callbacks, context and tools separately from toolkits

### DIFF
--- a/src/ai/toolkits/agents-toolkit.js
+++ b/src/ai/toolkits/agents-toolkit.js
@@ -1,6 +1,6 @@
-import SetAgentTool from '../tools/set-agent.js';
+import createSetAgentTool from '../tools/set-agent.js';
 
 export default {
 	name: 'agents',
-	tools: [ SetAgentTool ],
+	tools: ( context ) => [ createSetAgentTool( context.agents ) ],
 };

--- a/src/components/agent-controls.jsx
+++ b/src/components/agent-controls.jsx
@@ -107,6 +107,7 @@ const ChatAgentControls = () => {
 		agents,
 		activeAgent,
 		setActiveAgent,
+		setAgentStarted,
 	} = useAgents();
 	const { reset: onResetChat, running, enabled, setEnabled } = useChat();
 	const { reset: onResetToolkit } = useToolkits();
@@ -179,6 +180,7 @@ const ChatAgentControls = () => {
 					onResetChat();
 					onResetToolkit();
 					setActiveAgent( newAgentId );
+					setAgentStarted( false );
 				} }
 			/>
 			<HStack align="center">

--- a/src/components/assistants-demo-ui.jsx
+++ b/src/components/assistants-demo-ui.jsx
@@ -15,7 +15,6 @@ import PageList from './page-list.jsx';
 import { store as siteSpecStore } from '../store/index.js';
 import { useSelect } from '@wordpress/data';
 import useChatSettings from '../hooks/use-chat-settings.js';
-import useAgents from './agents-provider/use-agents.js';
 import {
 	AssistantModelService,
 	AssistantModelType,
@@ -65,13 +64,6 @@ const AssistantsDemoUI = ( { apiKey, onApiKeyChanged } ) => {
 	useGoalToolkit();
 	useInformToolkit();
 	useAgentExecutor();
-
-	const { setActiveAgent } = useAgents();
-
-	// set the initial agent
-	useEffect( () => {
-		setActiveAgent( WAPUU_AGENT_ID );
-	}, [ setActiveAgent ] );
 
 	const { pages } = useSelect( ( select ) => {
 		return {

--- a/src/components/toolkits-provider/use-toolkits.js
+++ b/src/components/toolkits-provider/use-toolkits.js
@@ -196,6 +196,7 @@ export default function useToolkits() {
 
 		// get the full set of tools from those toolkits
 		const toolkitTools = resolveToolkitTools( toolkits, allTools, context );
+
 		// get the subset of tools, if any, that the agent chooses
 		const agentTools = resolveAgentTools(
 			activeAgent,
@@ -223,14 +224,14 @@ export default function useToolkits() {
 		( requestedToolkits ) => {
 			return requestedToolkits.every( ( requestedToolkit ) => {
 				if ( typeof requestedToolkit === 'string' ) {
-					return toolkits.some(
+					return allToolkits.some(
 						( toolkit ) => toolkit.name === requestedToolkit
 					);
 				}
 				return true;
 			} );
 		},
-		[ toolkits ]
+		[ allToolkits ]
 	);
 
 	const reset = useCallback( () => {

--- a/src/store/chat.js
+++ b/src/store/chat.js
@@ -1100,11 +1100,6 @@ export const selectors = {
 	isThreadRunAwaitingToolOutputs: ( state ) => {
 		const threadRun = getActiveThreadRun( state );
 		const requiredToolOutputs = selectors.getRequiredToolOutputs( state );
-		console.warn( 'isThreadRunAwaitingToolOutputs', {
-			threadRun,
-			requiredToolOutputs,
-			isThreadDataLoaded: selectors.isThreadDataLoaded( state ),
-		} );
 		return (
 			selectors.isThreadDataLoaded( state ) &&
 			! selectors.isRunning( state ) &&

--- a/src/store/chat.js
+++ b/src/store/chat.js
@@ -209,7 +209,7 @@ const reset =
 		dispatch( clearMessages() );
 		dispatch( clearError() );
 		if ( threadId && isAssistantAvailable ) {
-			dispatch( deleteThread() );
+			dispatch( deleteThread );
 		}
 	};
 
@@ -299,7 +299,7 @@ const updateThreadRuns =
 			} );
 		} catch ( error ) {
 			console.error( 'Get Thread Runs Error', error );
-			return { type: 'GET_THREAD_RUNS_ERROR', error: error.message };
+			dispatch( { type: 'GET_THREAD_RUNS_ERROR', error: error.message } );
 		}
 	};
 
@@ -325,7 +325,7 @@ const updateThreadRun =
 			} );
 		} catch ( error ) {
 			console.error( 'Thread error', error );
-			return { type: 'GET_THREAD_RUN_ERROR', error: error.message };
+			dispatch( { type: 'GET_THREAD_RUN_ERROR', error: error.message } );
 		}
 	};
 
@@ -351,17 +351,22 @@ const updateThreadMessages =
 			} );
 		} catch ( error ) {
 			console.error( 'Get Thread Messages Error', error );
-			return { type: 'GET_THREAD_MESSAGES_ERROR', error: error.message };
+			dispatch( {
+				type: 'GET_THREAD_MESSAGES_ERROR',
+				error: error.message,
+			} );
 		}
 	};
 
 const getAssistantModel = ( select ) => {
-	const { service, apiKey, assistantId, feature } = select( ( state ) => ( {
-		service: state.root.service,
-		apiKey: state.root.apiKey,
-		assistantId: selectors.getAssistantId( state.root ),
-		feature: state.root.feature,
-	} ) );
+	const { service, apiKey, assistantId, feature } = select( ( state ) => {
+		return {
+			service: state.root.service,
+			apiKey: state.root.apiKey,
+			assistantId: selectors.getAssistantId( state.root ),
+			feature: state.root.feature,
+		};
+	} );
 	if ( ! service || ! apiKey || ! assistantId ) {
 		console.warn( 'Service, API key and assistant ID are required', {
 			service,
@@ -389,7 +394,7 @@ const createThread =
 			} );
 		} catch ( error ) {
 			console.error( 'Thread error', error );
-			return { type: 'CREATE_THREAD_ERROR', error: error.message };
+			dispatch( { type: 'CREATE_THREAD_ERROR', error: error.message } );
 		}
 	};
 
@@ -407,7 +412,7 @@ const deleteThread =
 			dispatch( agentsActions.setAgentStarted( false ) );
 		} catch ( error ) {
 			console.error( 'Thread error', error );
-			return { type: 'DELETE_THREAD_ERROR', error: error.message };
+			dispatch( { type: 'DELETE_THREAD_ERROR', error: error.message } );
 		}
 	};
 
@@ -897,18 +902,22 @@ export const reducer = ( state = initialState, action ) => {
 				( tr ) => tr.id === action.threadRun.id
 			);
 			if ( existingThreadRunIndex !== -1 ) {
-				state.threadRuns[ existingThreadRunIndex ] = action.threadRun;
+				state = {
+					...state,
+					threadRuns: [
+						...state.threadRuns.slice( 0, existingThreadRunIndex ),
+						action.threadRun,
+						...state.threadRuns.slice( existingThreadRunIndex + 1 ),
+					],
+				};
 			} else {
-				state.threadRuns = [
-					...state.threadRuns.filter(
-						( tr ) => tr.id !== action.threadRun.id
-					),
-					action.threadRun,
-				];
+				state = {
+					...state,
+					threadRuns: [ action.threadRun, ...state.threadRuns ],
+				};
 			}
 			return {
 				...state,
-				threadMessagesUpdated: null,
 				isFetchingThreadRun: false,
 			};
 		case 'GET_THREAD_RUN_ERROR':
@@ -1091,6 +1100,11 @@ export const selectors = {
 	isThreadRunAwaitingToolOutputs: ( state ) => {
 		const threadRun = getActiveThreadRun( state );
 		const requiredToolOutputs = selectors.getRequiredToolOutputs( state );
+		console.warn( 'isThreadRunAwaitingToolOutputs', {
+			threadRun,
+			requiredToolOutputs,
+			isThreadDataLoaded: selectors.isThreadDataLoaded( state ),
+		} );
 		return (
 			selectors.isThreadDataLoaded( state ) &&
 			! selectors.isRunning( state ) &&

--- a/src/store/toolkits.js
+++ b/src/store/toolkits.js
@@ -1,7 +1,7 @@
 import { createReduxStore } from '@wordpress/data';
 
 const initialState = {
-	toolkits: {},
+	toolkits: [],
 	contexts: {},
 	callbacks: {},
 	tools: {},
@@ -64,15 +64,25 @@ const registerToolkit = ( state, action ) => {
 		} );
 	}
 
+	// if there's an existing toolkit with the same name, replace it
+	const existingToolkitIndex = state.toolkits.findIndex(
+		( t ) => t.name === toolkit.name
+	);
+	if ( existingToolkitIndex !== -1 ) {
+		return {
+			...state,
+			toolkits: [
+				...state.toolkits.slice( 0, existingToolkitIndex ),
+				toolkit,
+				...state.toolkits.slice( existingToolkitIndex + 1 ),
+			],
+		};
+	}
+
+	// otherwise, add the new toolkit
 	return {
 		...state,
-		toolkits: {
-			...state.toolkits,
-			[ toolkit.name ]: {
-				name: toolkit.name,
-				description: toolkit.description,
-			},
-		},
+		toolkits: [ ...state.toolkits, toolkit ],
 	};
 };
 
@@ -126,7 +136,7 @@ export const reducer = ( state = initialState, action ) => {
 
 export const selectors = {
 	getToolkits: ( state ) => {
-		return Object.values( state.toolkits );
+		return state.toolkits;
 	},
 	getToolkit: ( state, name ) => {
 		return state.toolkits[ name ];

--- a/src/store/toolkits.js
+++ b/src/store/toolkits.js
@@ -1,7 +1,10 @@
 import { createReduxStore } from '@wordpress/data';
 
 const initialState = {
-	toolkits: [],
+	toolkits: {},
+	contexts: {},
+	callbacks: {},
+	tools: {},
 };
 
 export const actions = {
@@ -36,68 +39,74 @@ export const actions = {
 
 const registerToolkit = ( state, action ) => {
 	const { toolkit } = action;
-	const existingToolkitIndex = state.toolkits.findIndex(
-		( a ) => a.name === toolkit.name
-	);
 
-	if ( existingToolkitIndex !== -1 ) {
-		const updatedToolkits = [ ...state.toolkits ];
-		updatedToolkits[ existingToolkitIndex ] = toolkit;
-		return { ...state, toolkits: updatedToolkits };
+	// if the toolkit includes callbacks, register the callbacks
+	if ( toolkit.callbacks ) {
+		state = setCallbacks( state, {
+			name: toolkit.name,
+			callbacks: toolkit.callbacks,
+		} );
 	}
-	// If tool with the same ID doesn't exist, add the new tool to the array
-	return { ...state, toolkits: [ ...state.toolkits, toolkit ] };
+
+	// if the toolkit includes context, register the context
+	if ( toolkit.context ) {
+		state = setContext( state, {
+			name: toolkit.name,
+			context: toolkit.context,
+		} );
+	}
+
+	// if the toolkit includes tools, register the tools
+	if ( toolkit.tools ) {
+		state = setTools( state, {
+			name: toolkit.name,
+			tools: toolkit.tools,
+		} );
+	}
+
+	return {
+		...state,
+		toolkits: {
+			...state.toolkits,
+			[ toolkit.name ]: {
+				name: toolkit.name,
+				description: toolkit.description,
+			},
+		},
+	};
 };
 
 const setCallbacks = ( state, action ) => {
 	const { name, callbacks } = action;
-	const toolkitIndex = state.toolkits.findIndex( ( a ) => a.name === name );
-	if ( toolkitIndex === -1 ) {
-		// register the toolkit instead
-		return registerToolkit( state, { toolkit: { name, callbacks } } );
-	}
-	const toolkitToUpdate = state.toolkits[ toolkitIndex ];
-	const updatedToolkit = {
-		...toolkitToUpdate,
-		callbacks,
+	return {
+		...state,
+		callbacks: {
+			...state.callbacks,
+			[ name ]: callbacks,
+		},
 	};
-	const updatedToolkits = [ ...state.toolkits ];
-	updatedToolkits[ toolkitIndex ] = updatedToolkit;
-	return { ...state, toolkits: updatedToolkits };
 };
 
 const setContext = ( state, action ) => {
 	const { name, context } = action;
-	const toolkitIndex = state.toolkits.findIndex( ( a ) => a.name === name );
-	if ( toolkitIndex === -1 ) {
-		// register the toolkit instead
-		return registerToolkit( state, { toolkit: { name, context } } );
-	}
-	const toolkitToUpdate = state.toolkits[ toolkitIndex ];
-	const updatedToolkit = {
-		...toolkitToUpdate,
-		context,
+	return {
+		...state,
+		contexts: {
+			...state.contexts,
+			[ name ]: context,
+		},
 	};
-	const updatedToolkits = [ ...state.toolkits ];
-	updatedToolkits[ toolkitIndex ] = updatedToolkit;
-	return { ...state, toolkits: updatedToolkits };
 };
 
 const setTools = ( state, action ) => {
 	const { name, tools } = action;
-	const toolkitIndex = state.toolkits.findIndex( ( a ) => a.name === name );
-	if ( toolkitIndex === -1 ) {
-		// register the toolkit instead
-		return registerToolkit( state, { toolkit: { name, tools } } );
-	}
-	const toolkitToUpdate = state.toolkits[ toolkitIndex ];
-	const updatedToolkit = {
-		...toolkitToUpdate,
-		tools,
+	return {
+		...state,
+		tools: {
+			...state.tools,
+			[ name ]: tools,
+		},
 	};
-	const updatedToolkits = [ ...state.toolkits ];
-	updatedToolkits[ toolkitIndex ] = updatedToolkit;
-	return { ...state, toolkits: updatedToolkits };
 };
 
 export const reducer = ( state = initialState, action ) => {
@@ -117,7 +126,19 @@ export const reducer = ( state = initialState, action ) => {
 
 export const selectors = {
 	getToolkits: ( state ) => {
-		return state.toolkits;
+		return Object.values( state.toolkits );
+	},
+	getToolkit: ( state, name ) => {
+		return state.toolkits[ name ];
+	},
+	getContexts: ( state ) => {
+		return state.contexts;
+	},
+	getCallbacks: ( state ) => {
+		return state.callbacks;
+	},
+	getTools: ( state ) => {
+		return state.tools;
 	},
 };
 


### PR DESCRIPTION
We had an issue integrating in the Big Sky Plugin where if you have an inline toolkit (declared directly in the agent) and then set the context, the context doesn't get updated because it's still reading it from the "Toolkit" object rather than where it was actually saved, the toolkit.js slice of the store.

This patch changes things so that when you register a toolkit, it stores the context in its own part of the store, separate from the toolkit. It also does this for callbacks and tools. This allows these to be set even for inline tool instances, and the values passed from the toolkit are re-written during the registerToolkit store action.

Also:
 * start an agent when you switch agents manually
 * fix bug deleting threads, needed to pass a function not call a function
 * better performance by lazy-converting tools to openai format
 * fix a bug of bugs hanging around in our actions (not dispatching properly in redux thunks, which meant we weren't catching errors correctly)
 * less state mutation in the store == less bugs
 