### PR TITLE
Prevents crash when setting activeAgentId in AgentProvider

### DIFF
--- a/src/components/toolkits-provider/use-toolkits.js
+++ b/src/components/toolkits-provider/use-toolkits.js
@@ -154,7 +154,7 @@ export default function useToolkits() {
 	const callbacks = useMemo( () => {
 		return toolkits?.reduce( ( acc, toolkit ) => {
 			const toolkitCallbacks =
-				toolkit.callbacks ?? allCallbacks[ toolkit.name ];
+				toolkit?.callbacks ?? allCallbacks[ toolkit.name ];
 
 			if ( ! toolkitCallbacks ) {
 				return acc;


### PR DESCRIPTION
In Big Sky, when trying to set the active agent ID in `AgentsProvider`, the app would crash.

```
<AgentsProvider
  activeAgentId={ managerAgent.id }
  agents={ agents }
>
  ...
</AgentsProvider>
```
