### PR TITLE
Add bundle splitting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ llama.log
 # ignore anything in ./models that's NOT a yaml file
 models/*
 !models/*.yaml
+stats.html

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,6 +78,7 @@
         "rollup-plugin-ignore": "^1.0.10",
         "rollup-plugin-postcss": "^4.0.2",
         "rollup-plugin-sass": "^1.12.22",
+        "rollup-plugin-visualizer": "^5.12.0",
         "rollup-preserve-directives": "^1.1.1",
         "storybook": "^8.1.11",
         "tail": "^2.2.6",
@@ -85,8 +86,7 @@
         "ts-node": "^10.9.2",
         "typescript": "^5.3.3",
         "vite": "^5.2.13",
-        "vite-plugin-dts": "^4.0.0-beta.0",
-        "webpack": "^5.91.0"
+        "vite-plugin-dts": "^4.0.0-beta.0"
       },
       "peerDependencies": {
         "react": "^18.3.1",
@@ -31423,6 +31423,61 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/rollup-plugin-visualizer": {
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-visualizer/-/rollup-plugin-visualizer-5.12.0.tgz",
+      "integrity": "sha512-8/NU9jXcHRs7Nnj07PF2o4gjxmm9lXIrZ8r175bT9dK8qoLlvKTwRMArRCMgpMGlq8CTLugRvEmyMeMXIU2pNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "open": "^8.4.0",
+        "picomatch": "^2.3.1",
+        "source-map": "^0.7.4",
+        "yargs": "^17.5.1"
+      },
+      "bin": {
+        "rollup-plugin-visualizer": "dist/bin/cli.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "rollup": "2.x || 3.x || 4.x"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/rollup-plugin-visualizer/node_modules/open": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/rollup-plugin-visualizer/node_modules/source-map": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/rollup-pluginutils": {

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "rollup-plugin-ignore": "^1.0.10",
     "rollup-plugin-postcss": "^4.0.2",
     "rollup-plugin-sass": "^1.12.22",
+    "rollup-plugin-visualizer": "^5.12.0",
     "rollup-preserve-directives": "^1.1.1",
     "storybook": "^8.1.11",
     "tail": "^2.2.6",
@@ -113,8 +114,7 @@
     "ts-node": "^10.9.2",
     "typescript": "^5.3.3",
     "vite": "^5.2.13",
-    "vite-plugin-dts": "^4.0.0-beta.0",
-    "webpack": "^5.91.0"
+    "vite-plugin-dts": "^4.0.0-beta.0"
   },
   "peerDependencies": {
     "react": "^18.3.1",

--- a/src/components/ask-user.jsx
+++ b/src/components/ask-user.jsx
@@ -11,7 +11,7 @@ import {
 	__experimentalItemGroup as ItemGroup,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import MessageInput from './message-input.jsx';
 import AskUserTool from '../ai/tools/ask-user.js';
 import withToolCall from './with-tool-call.jsx';

--- a/src/components/assistants-demo-ui.jsx
+++ b/src/components/assistants-demo-ui.jsx
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from '@wordpress/element';
 import { Flex } from '@wordpress/components';
 
 /**

--- a/src/components/chat-demo-ui.jsx
+++ b/src/components/chat-demo-ui.jsx
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useCallback, useState } from 'react';
+import { useCallback, useState } from '@wordpress/element';
 import { Flex } from '@wordpress/components';
 
 /**

--- a/src/components/confirm.jsx
+++ b/src/components/confirm.jsx
@@ -1,7 +1,7 @@
 import { Button, Card, CardBody, CardFooter } from '@wordpress/components';
 import MessageContent from './message-content.jsx';
 import { CONFIRM_TOOL_NAME } from '../ai/tools/confirm.js';
-import { useCallback } from 'react';
+import { useCallback } from '@wordpress/element';
 import withToolCall from './with-tool-call.jsx';
 
 function Confirm( { args, respond, onConfirm } ) {

--- a/src/components/message-input.jsx
+++ b/src/components/message-input.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import {
 	Button,
 	DropZone,

--- a/src/components/page-spec-preview.jsx
+++ b/src/components/page-spec-preview.jsx
@@ -7,7 +7,7 @@ import { FakeBrowser } from '@vtaits/react-fake-browser-ui';
  * WordPress dependencies
  */
 import { Card, CardBody } from '@wordpress/components';
-import { useEffect, useState } from 'react';
+import { useEffect, useState } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 // import {
 // 	BlockCanvas,

--- a/src/components/popup-controls.jsx
+++ b/src/components/popup-controls.jsx
@@ -3,7 +3,7 @@ import { close, settings } from '@wordpress/icons';
 import ChatModelControls from './chat-model-controls.jsx';
 import AgentControls from './agent-controls.jsx';
 import ToolCallControls from './tool-call-controls.jsx';
-import { useEffect, useState } from 'react';
+import { useEffect, useState } from '@wordpress/element';
 import './popup-controls.scss';
 
 const PopUpControls = ( { setApiKey } ) => {

--- a/src/components/site-spec-preview.jsx
+++ b/src/components/site-spec-preview.jsx
@@ -11,7 +11,7 @@ import {
 } from '@wordpress/components';
 import { store as siteSpecStore } from '../store/index.js';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useState } from 'react';
+import { useState } from '@wordpress/element';
 
 function CorrectableTextField( { disabled, label, value, onChange } ) {
 	const [ isEditing, setIsEditing ] = useState( false );

--- a/src/components/user-message-input.jsx
+++ b/src/components/user-message-input.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from '@wordpress/element';
 import MessageInput from './message-input.jsx';
 import useChat from './chat-provider/use-chat.js';
 

--- a/src/hooks/use-analyze-site-toolkit.js
+++ b/src/hooks/use-analyze-site-toolkit.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useEffect } from 'react';
+import { useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies

--- a/src/hooks/use-chat-icon.js
+++ b/src/hooks/use-chat-icon.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { useRive, useStateMachineInput } from '@rive-app/react-canvas';
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies

--- a/src/hooks/use-chat-model.js
+++ b/src/hooks/use-chat-model.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useEffect, useState } from 'react';
+import { useEffect, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies

--- a/src/vendor.js
+++ b/src/vendor.js
@@ -1,0 +1,9 @@
+// src/vendor.js
+import '@wordpress/element';
+import '@wordpress/components';
+import '@wordpress/data';
+import '@wordpress/icons';
+import '@wordpress/blocks';
+import 'react';
+import 'prop-types';
+// Import other @wordpress dependencies as needed

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -4,6 +4,7 @@ import hq from 'alias-hq';
 import external from '@yelo/rollup-node-external';
 import dts from 'vite-plugin-dts';
 import postcssPresetEnv from 'postcss-preset-env';
+import { visualizer } from 'rollup-plugin-visualizer';
 
 // https://vitejs.dev/config/
 export default defineConfig( {
@@ -17,6 +18,7 @@ export default defineConfig( {
 	plugins: [
 		react(),
 		dts( { rollupTypes: true, exclude: [ '**/*.stories.(ts|tsx)' ] } ),
+		visualizer(),
 	],
 	build: {
 		sourcemap: true,


### PR DESCRIPTION
An experiment to reduce client bundle size by externalizing common dependencies.

 * react
 * prop-types
 * @wordpress/*