### PR TITLE
Remove useTools and fix module setup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,13 @@
 {
   "name": "@automattic/big-sky-agents",
-  "version": "1.1.38",
+  "version": "1.1.39",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@automattic/big-sky-agents",
-      "version": "1.1.38",
+      "version": "1.1.39",
       "license": "GPL-2.0-or-later",
-      "bin": {
-        "big-sky-eval": "bin/eval.js"
-      },
       "devDependencies": {
         "@babel/eslint-parser": "^7.24.7",
         "@babel/plugin-syntax-import-assertions": "^7.24.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@automattic/big-sky-agents",
-  "version": "1.1.39",
+  "version": "1.1.40",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@automattic/big-sky-agents",
-      "version": "1.1.39",
+      "version": "1.1.40",
       "license": "GPL-2.0-or-later",
       "devDependencies": {
         "@babel/eslint-parser": "^7.24.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automattic/big-sky-agents",
-  "version": "1.1.39",
+  "version": "1.1.40",
   "description": "The Big Sky Agents SDK",
   "repository": {
     "type": "git",
@@ -14,8 +14,7 @@
   "files": [
     "dist",
     "bin",
-    "eval.js",
-    "eval.cjs"
+    "src"
   ],
   "exports": {
     ".": {
@@ -133,7 +132,9 @@
   },
   "peerDependencies": {
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "@rive-app/react-canvas": "^4.11.3",
+    "@vtaits/react-fake-browser-ui": "^1.0.0"
   },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automattic/big-sky-agents",
-  "version": "1.1.38",
+  "version": "1.1.39",
   "description": "The Big Sky Agents SDK",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "license": "GPL-2.0-or-later",
   "type": "module",
   "main": "dist/index.cjs",
-  "module": "dist/index.js",
+  "module": "src/index.js",
   "files": [
     "dist",
     "bin",
@@ -19,7 +19,7 @@
   ],
   "exports": {
     ".": {
-      "import": "./dist/index.js",
+      "import": "./src/index.js",
       "require": "./dist/index.cjs"
     },
     "./eval": {

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -15,12 +15,12 @@ export default [
 		input: 'src/index.js',
 		output: [
 			{
-				file: packageJson.main,
+				file: 'dist/index.cjs',
 				format: 'cjs',
 				sourcemap: true,
 			},
 			{
-				file: packageJson.module,
+				file: 'dist/index.js',
 				format: 'esm',
 				sourcemap: true,
 			},

--- a/src/components/chat-provider/index.js
+++ b/src/components/chat-provider/index.js
@@ -1,2 +1,2 @@
 export { default as ChatProvider, ChatConsumer } from './context.jsx';
-export { default as useChat } from './use-chat';
+export { default as useChat } from './use-chat.js';

--- a/src/components/toolkits-provider/context.jsx
+++ b/src/components/toolkits-provider/context.jsx
@@ -2,7 +2,7 @@ import { dispatch, register } from '@wordpress/data';
 import { createContext } from '@wordpress/element';
 import { store as defaultToolkitsStore } from '../../store/index.js';
 import { createToolkitsStore } from '../../store/toolkits.js';
-import defaultToolkits from '../../ai/toolkits/default-toolkits';
+import defaultToolkits from '../../ai/toolkits/default-toolkits.js';
 import uuidv4 from '../../utils/uuid.js';
 
 defaultToolkits.forEach( ( toolkit ) => {

--- a/src/components/toolkits-provider/index.js
+++ b/src/components/toolkits-provider/index.js
@@ -1,3 +1,3 @@
 export { default as ToolkitsProvider, ToolkitsConsumer } from './context.jsx';
-export { default as useToolkits } from './use-toolkits';
-export { default as useToolkit } from './use-toolkit';
+export { default as useToolkits } from './use-toolkits.js';
+export { default as useToolkit } from './use-toolkit.js';

--- a/src/components/toolkits-provider/use-toolkits.js
+++ b/src/components/toolkits-provider/use-toolkits.js
@@ -7,8 +7,8 @@ import { useDispatch, useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import defaultToolkits from '../../ai/toolkits/default-toolkits';
-import useAgents from '../agents-provider/use-agents';
+import defaultToolkits from '../../ai/toolkits/default-toolkits.js';
+import useAgents from '../agents-provider/use-agents.js';
 
 /**
  * Internal dependencies
@@ -120,7 +120,7 @@ function resolveAgentTools( agent, context, toolkitTools ) {
 export default function useToolkits() {
 	const toolkitsStore = useContext( Context );
 	const { activeAgent } = useAgents();
-	const { registerToolkit, setCallbacks, setContext, setTools } =
+	const { registerToolkit, setCallbacks, setContext } =
 		useDispatch( toolkitsStore );
 	const { call, agentSay, userSay } = useChat();
 	const {
@@ -253,7 +253,6 @@ export default function useToolkits() {
 		registerToolkit,
 		setCallbacks,
 		setContext,
-		setTools,
 		registerDefaultToolkits,
 	};
 }

--- a/src/hooks/use-agents-toolkit.js
+++ b/src/hooks/use-agents-toolkit.js
@@ -6,20 +6,14 @@ import { useEffect } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import createSetAgentTool, {
-	SET_AGENT_TOOL_NAME,
-} from '../ai/tools/set-agent.js';
+import { SET_AGENT_TOOL_NAME } from '../ai/tools/set-agent.js';
 import useAgents from '../components/agents-provider/use-agents.js';
 import useToolkits from '../components/toolkits-provider/use-toolkits.js';
 import AgentsToolkit from '../ai/toolkits/agents-toolkit.js';
 
 const useAgentsToolkit = () => {
 	const { agents, activeAgent, setActiveAgent } = useAgents();
-	const { setTools, setCallbacks, setContext } = useToolkits();
-
-	useEffect( () => {
-		setTools( AgentsToolkit.name, [ createSetAgentTool( agents ) ] );
-	}, [ agents, setTools ] );
+	const { setCallbacks, setContext } = useToolkits();
 
 	useEffect( () => {
 		setCallbacks( AgentsToolkit.name, {

--- a/src/hooks/use-chat-settings.js
+++ b/src/hooks/use-chat-settings.js
@@ -1,5 +1,5 @@
 import { useEffect } from '@wordpress/element';
-import useChat from '../components/chat-provider/use-chat';
+import useChat from '../components/chat-provider/use-chat.js';
 import useAgents from '../components/agents-provider/use-agents.js';
 
 const useChatSettings = ( options ) => {

--- a/src/store/toolkits.js
+++ b/src/store/toolkits.js
@@ -28,13 +28,6 @@ export const actions = {
 			context,
 		};
 	},
-	setTools: ( name, tools ) => {
-		return {
-			type: 'REGISTER_TOOLKIT_TOOLS',
-			name,
-			tools,
-		};
-	},
 };
 
 const registerToolkit = ( state, action ) => {


### PR DESCRIPTION
 * instruct ESM module consumers to load src/index.js instead of dist/index.js. This enables browser builds to only load the files they need, and to manage their dependencies on things like WordPress components or React.
 * remove `setTools` from `useToolkits`. Toolkits should use `tools: ( context ) => { ... }` to dynamically build/return tools based on the context.