### PR TITLE
Remove setTools and clean up imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,13 @@
 {
   "name": "@automattic/big-sky-agents",
-  "version": "1.1.38",
+  "version": "1.1.41",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@automattic/big-sky-agents",
-      "version": "1.1.38",
+      "version": "1.1.41",
       "license": "GPL-2.0-or-later",
-      "bin": {
-        "big-sky-eval": "bin/eval.js"
-      },
       "devDependencies": {
         "@babel/eslint-parser": "^7.24.7",
         "@babel/plugin-syntax-import-assertions": "^7.24.7",
@@ -39,18 +36,9 @@
         "@typescript-eslint/eslint-plugin": "^7.12.0",
         "@vitejs/plugin-react": "^4.3.0",
         "@vtaits/react-fake-browser-ui": "^1.0.0",
-        "@wordpress/api-fetch": "^7.0.0",
-        "@wordpress/base-styles": "^5.0.0",
-        "@wordpress/components": "^28.0.0",
-        "@wordpress/data": "^10.0.0",
-        "@wordpress/element": "^6.1.0",
         "@wordpress/env": "^10.0.0",
         "@wordpress/eslint-plugin": "^20.0.0",
-        "@wordpress/i18n": "^5.0.0",
-        "@wordpress/icons": "^10.0.0",
         "@wordpress/prettier-config": "^4.0.0",
-        "@wordpress/private-apis": "^1.0.0",
-        "@wordpress/router": "^1.0.0",
         "@wordpress/scripts": "^28.0.0",
         "@yelo/rollup-node-external": "^1.0.1",
         "alias-hq": "^6.2.3",
@@ -76,7 +64,6 @@
         "prompt-sync": "^4.2.0",
         "react-markdown": "^9.0.1",
         "redux-devtools-extension": "^2.13.9",
-        "rememo": "^4.0.2",
         "rollup": "^4.18.0",
         "rollup-plugin-copy": "^3.5.0",
         "rollup-plugin-dts": "^6.1.1",
@@ -94,6 +81,15 @@
         "webpack": "^5.91.0"
       },
       "peerDependencies": {
+        "@wordpress/api-fetch": "^7.0.0",
+        "@wordpress/base-styles": "^5.0.0",
+        "@wordpress/components": "^28.0.0",
+        "@wordpress/data": "^10.0.0",
+        "@wordpress/element": "^6.1.0",
+        "@wordpress/i18n": "^5.0.0",
+        "@wordpress/icons": "^10.0.0",
+        "@wordpress/private-apis": "^1.0.0",
+        "@wordpress/router": "^1.0.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       }
@@ -123,15 +119,15 @@
       "version": "0.3.11",
       "resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.3.11.tgz",
       "integrity": "sha512-+MnOeqnA4FLI/7vqsZLbZQHHN4ofd9kvkNjz44fNi0gqmD+ZbMWiDkFAvZII75dYnxYw5ZPpWjA4waK22VBWig==",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@ariakit/react": {
       "version": "0.3.14",
       "resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.3.14.tgz",
       "integrity": "sha512-h71BPMZ2eW+E2ESbdYxSAEMR1DozYzd5eHE5IOzGd9Egi5u7EZxqmuW4CXVXZ1Y6vbaDMV3SudgPh7iHS/ArFw==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ariakit/react-core": "0.3.14"
       },
@@ -148,8 +144,8 @@
       "version": "0.3.14",
       "resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.3.14.tgz",
       "integrity": "sha512-16Qj6kDPglpdWtU5roY9q+G66naOjauTY5HvUIaL2aLY0187ATaRrABIKoMMzTtJyhvsud4jFlzivz+/zCQ8yw==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ariakit/core": "0.3.11",
         "@floating-ui/dom": "^1.0.0",
@@ -164,7 +160,6 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
       "integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/highlight": "^7.24.7",
@@ -238,7 +233,6 @@
       "version": "7.24.10",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.10.tgz",
       "integrity": "sha512-o9HBZL1G2129luEUlG1hB4N/nlYNWHnpwlND9eOMclRqqu1YDy2sSYVCFUZwl8I1Gxh+QSRrP2vD7EpUmFVXxg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.24.9",
@@ -357,7 +351,6 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.24.7.tgz",
       "integrity": "sha512-DoiN84+4Gnd0ncbBOM9AZENV4a5ZiL39HYMyZJGZ/AZEykHYdJw0wW3kdcsh9/Kn+BRXHLkkklZ51ecPKmI1CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.24.7"
@@ -370,7 +363,6 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.24.7.tgz",
       "integrity": "sha512-FyoJTsj/PEUWu1/TYRiXTIHc8lbw+TDYkZuoE43opPS5TrI7MyONBE1oNvfguEXAD9yhQRrVBnXdXzSLQl9XnA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.24.7",
@@ -384,7 +376,6 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.24.7.tgz",
       "integrity": "sha512-MJJwhkoGy5c4ehfoRyrJ/owKeMl19U54h27YYftT0o2teQ3FJ3nQUf/I3LlJsX4l3qlw7WRXUmiyajvHXoTubQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.24.7"
@@ -411,7 +402,6 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.7.tgz",
       "integrity": "sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.24.7",
@@ -532,7 +522,6 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.7.tgz",
       "integrity": "sha512-oy5V7pD+UvfkEATUKvIjvIAH/xCzfsFVw7ygW2SI6NClZzquT+mwdTfgfdbUiceh6iQO0CHtCPsyze/MZ2YbAA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.24.7"
@@ -545,7 +534,6 @@
       "version": "7.24.8",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.8.tgz",
       "integrity": "sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -555,7 +543,6 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
       "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -605,7 +592,6 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
       "integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.24.7",
@@ -621,7 +607,6 @@
       "version": "7.24.8",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.8.tgz",
       "integrity": "sha512-WzfbgXOkGzZiXXCqk43kKwZjzwx4oulxZi3nq2TYL9mOjQv6kYwul9mz6ID36njuL7Xkp6nJEfok848Zj10j/w==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -2413,7 +2398,6 @@
       "version": "7.24.8",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.8.tgz",
       "integrity": "sha512-5F7SDGs1T72ZczbRwbGO9lQi0NLjQxzl6i4lJxLxfW9U5UluCSyEJeniWvnhl3/euNiqQVbo8zruhsDfid0esA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
@@ -2426,7 +2410,6 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.7.tgz",
       "integrity": "sha512-jYqfPrU9JTF0PmPy1tLYHW4Mp4KlgxJD9l2nP9fD6yT/ICi554DmrWBAEYpIelzjHf1msDP3PxJIRt/nFNfBig==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.24.7",
@@ -2441,7 +2424,6 @@
       "version": "7.24.8",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.8.tgz",
       "integrity": "sha512-t0P1xxAPzEDcEPmjprAQq19NWum4K0EQPjMwZQZbHt+GiZqvjCHjj755Weq1YRPVzBI+3zSfvScfpnuIecVFJQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.24.7",
@@ -2463,7 +2445,6 @@
       "version": "7.24.9",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.9.tgz",
       "integrity": "sha512-xm8XrMKz0IlUdocVbYJe0Z9xEgidU7msskG8BbhnTPK/HZ2z/7FP7ykqPgrUH+C+r414mNfNWam1f2vqOjqjYQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.24.8",
@@ -3592,8 +3573,8 @@
       "version": "11.11.0",
       "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.11.0.tgz",
       "integrity": "sha512-m4HEDZleaaCH+XgDDsPF15Ht6wTLsgDTeR3WYj9Q/k76JtWhrJjcP4+/XlG8LGT/Rol9qUfOIztXeA84ATpqPQ==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.16.7",
         "@babel/runtime": "^7.18.3",
@@ -3612,15 +3593,15 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@emotion/cache": {
       "version": "11.11.0",
       "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.11.0.tgz",
       "integrity": "sha512-P34z9ssTCBi3e9EI1ZsWpNHcfY1r09ZO0rZbRO2ob3ZQMnFI35jB536qoXbkdesr5EUhYi22anuEJuyxifaqAQ==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emotion/memoize": "^0.8.1",
         "@emotion/sheet": "^1.2.2",
@@ -3633,8 +3614,8 @@
       "version": "11.11.2",
       "resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.11.2.tgz",
       "integrity": "sha512-VJxe1ucoMYMS7DkiMdC2T7PWNbrEI0a39YRiyDvK2qq4lXwjRbVP/z4lpG+odCsRzadlR+1ywwrTzhdm5HNdew==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emotion/babel-plugin": "^11.11.0",
         "@emotion/cache": "^11.11.0",
@@ -3647,14 +3628,13 @@
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.1.tgz",
       "integrity": "sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ==",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@emotion/is-prop-valid": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.2.tgz",
       "integrity": "sha512-uNsoYd37AFmaCdXlg6EYD1KaPOaRWRByMCYzbKUX4+hhMfrxdVSelShywL4JVaAeM/eHUOSprYBQls+/neX3pw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@emotion/memoize": "^0.8.1"
@@ -3664,15 +3644,14 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
       "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@emotion/react": {
       "version": "11.11.4",
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.11.4.tgz",
       "integrity": "sha512-t8AjMlF0gHpvvxk5mAtCqR4vmxiGHCeJBaQO6gncUSdklELOgtwjerNY2yuJNfwnc6vi16U/+uMF+afIawJ9iw==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.11.0",
@@ -3696,8 +3675,8 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.4.tgz",
       "integrity": "sha512-RIN04MBT8g+FnDwgvIUi8czvr1LU1alUMI05LekWB5DGyTm8cCBMCRpq3GqaiyEDRptEXOyXnvZ58GZYu4kBxQ==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emotion/hash": "^0.9.1",
         "@emotion/memoize": "^0.8.1",
@@ -3710,15 +3689,15 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.2.2.tgz",
       "integrity": "sha512-0QBtGvaqtWi+nx6doRwDdBIzhNdZrXUppvTM4dtZZWEGTXL/XE/yJxLMGlDT1Gt+UHH5IX1n+jkXyytE/av7OA==",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@emotion/styled": {
       "version": "11.11.5",
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.11.5.tgz",
       "integrity": "sha512-/ZjjnaNKvuMPxcIiUkf/9SHoG4Q196DRl1w82hQ3WCsjo1IUR8uaGWrC6a87CrYAW0Kb/pK7hk8BnLgLRi9KoQ==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.11.0",
@@ -3741,15 +3720,15 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.1.tgz",
       "integrity": "sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ==",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.1.tgz",
       "integrity": "sha512-jT/qyKZ9rzLErtrjGgdkMBn2OP8wl0G3sQlBb3YPryvKHsjvINUhVaPFfP+fpBcOkmrVOVEEHQFJ7nbj2TH2gw==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "react": ">=16.8.0"
       }
@@ -3758,15 +3737,15 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.2.1.tgz",
       "integrity": "sha512-Y2tGf3I+XVnajdItskUCn6LX+VUDmP6lTL4fcqsXAv43dnlbZiuW4MWQW38rW/BVWSE7Q/7+XQocmpnRYILUmg==",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@emotion/weak-memoize": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.3.1.tgz",
       "integrity": "sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww==",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@es-joy/jsdoccomment": {
       "version": "0.41.0",
@@ -4324,8 +4303,8 @@
       "version": "1.6.4",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.4.tgz",
       "integrity": "sha512-a4IowK4QkXl4SCWTGUR0INAfEOX3wtsYw3rKK5InQEHMGObkR8Xk44qYQD9P4r6HHw0iIfK6GUKECmY8sTkqRA==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@floating-ui/utils": "^0.2.4"
       }
@@ -4334,8 +4313,8 @@
       "version": "1.6.7",
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.7.tgz",
       "integrity": "sha512-wmVfPG5o2xnKDU4jx/m4w5qva9FWHcnZ8BvzEe90D/RpwsJaTAVYPEPdQ8sbr/N8zZTAHlZUTQdqg8ZUbzHmng==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@floating-ui/core": "^1.6.0",
         "@floating-ui/utils": "^0.2.4"
@@ -4345,8 +4324,8 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.1.tgz",
       "integrity": "sha512-4h84MJt3CHrtG18mGsXuLCHMrug49d7DFkU0RMIyshRveBeyV2hmV/pDaF2Uxtu8kgq5r46llp5E5FQiR0K2Yg==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@floating-ui/dom": "^1.0.0"
       },
@@ -4359,8 +4338,8 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.4.tgz",
       "integrity": "sha512-dWO2pw8hhi+WrXq1YJy2yCuWoL20PddgGaqTgVe4cOS9Q6qklXCiA1tJEqX6BEwRNSCP84/afac9hd4MS+zEUA==",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@fortawesome/fontawesome-common-types": {
       "version": "6.6.0",
@@ -5434,7 +5413,6 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
       "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/set-array": "^1.2.1",
@@ -5449,7 +5427,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -5459,7 +5436,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
       "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -5480,14 +5456,12 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
       "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.25",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
       "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -8351,8 +8325,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@tannin/compile/-/compile-1.1.0.tgz",
       "integrity": "sha512-n8m9eNDfoNZoxdvWiTfW/hSPhehzLJ3zW7f8E7oT6mCROoMNWCB4TYtv041+2FMAxweiE0j7i1jubQU4MEC/Gg==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tannin/evaluate": "^1.2.0",
         "@tannin/postfix": "^1.1.0"
@@ -8362,15 +8336,15 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@tannin/evaluate/-/evaluate-1.2.0.tgz",
       "integrity": "sha512-3ioXvNowbO/wSrxsDG5DKIMxC81P0QrQTYai8zFNY+umuoHWRPbQ/TuuDEOju9E+jQDXmj6yI5GyejNuh8I+eg==",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@tannin/plural-forms": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@tannin/plural-forms/-/plural-forms-1.1.0.tgz",
       "integrity": "sha512-xl9R2mDZO/qiHam1AgMnAES6IKIg7OBhcXqy6eDsRCdXuxAFPcjrej9HMjyCLE0DJ/8cHf0i5OQTstuBRhpbHw==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tannin/compile": "^1.1.0"
       }
@@ -8379,8 +8353,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@tannin/postfix/-/postfix-1.1.0.tgz",
       "integrity": "sha512-oocsqY7g0cR+Gur5jRQLSrX2OtpMLMse1I10JQBm8CdGMrDkh1Mg2gjsiquMHRtBs4Qwu5wgEp5GgIYHk4SNPw==",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@testing-library/dom": {
       "version": "10.3.2",
@@ -8900,8 +8874,8 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@types/gradient-parser/-/gradient-parser-0.1.3.tgz",
       "integrity": "sha512-XDbrTSBlQV9nxE1GiDL3FaOPy4G/KaJkhDutBX48Kg8CYZMBARyyDFGCWfWJn4pobmInmwud1xxH7VJMAr0CKQ==",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/hast": {
       "version": "3.0.4",
@@ -8917,8 +8891,8 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/highlight-words-core/-/highlight-words-core-1.2.1.tgz",
       "integrity": "sha512-9VZUA5omXBfn+hDxFjUDu1FOJTBM3LmvqfDey+Z6Aa8B8/JmF5SMj6FBrjfgJ/Q3YXOZd3qyTDfJyMZSs/wCUA==",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/http-cache-semantics": {
       "version": "4.0.4",
@@ -9056,8 +9030,8 @@
       "version": "1.6.15",
       "resolved": "https://registry.npmjs.org/@types/mousetrap/-/mousetrap-1.6.15.tgz",
       "integrity": "sha512-qL0hyIMNPow317QWW/63RvL1x5MVMV+Ru3NaY9f/CuEpCqrmb7WeuK2071ZY5hczOnm38qExWM2i2WtkXLSqFw==",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/ms": {
       "version": "0.7.34",
@@ -9110,14 +9084,12 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
       "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.12",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.12.tgz",
       "integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/qs": {
@@ -9138,7 +9110,6 @@
       "version": "18.3.3",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
       "integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -9149,8 +9120,8 @@
       "version": "18.3.0",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
       "integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -9615,15 +9586,15 @@
       "version": "10.3.1",
       "resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.3.1.tgz",
       "integrity": "sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@use-gesture/react": {
       "version": "10.3.1",
       "resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.3.1.tgz",
       "integrity": "sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@use-gesture/core": "10.3.1"
       },
@@ -10074,8 +10045,8 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.3.0.tgz",
       "integrity": "sha512-kmAE8hshmldudMhtj/RKY7lEwyux5w6zvCTbIj3a6iq0ZMhU3vsxTlCp/vEGLoYdfetwRN4zeJA9jvPki+IOUA==",
-      "dev": true,
       "license": "GPL-2.0-or-later",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.16.0",
         "@wordpress/dom-ready": "^4.3.0",
@@ -10090,8 +10061,8 @@
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.3.0.tgz",
       "integrity": "sha512-VpHG+9cLRZG13V2t1+xXpwuHJCeqiOl0ent9qXzbe6am9DtKSJ3oxiNdZaHjs6tdgGNuN/mTowRi5ceYJZb83Q==",
-      "dev": true,
       "license": "GPL-2.0-or-later",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.16.0",
         "@wordpress/i18n": "^5.3.0",
@@ -10130,7 +10101,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-5.3.0.tgz",
       "integrity": "sha512-2Azr6XLCejtEzxhTv71x1VS30D5k0xL91CGRL1PTlnBRe/3Ki09hvz45kr52BI6YWnKtDUvCBw1USiGB9UJhgw==",
-      "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -10152,8 +10122,8 @@
       "version": "28.3.0",
       "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-28.3.0.tgz",
       "integrity": "sha512-zLHtxmhbuD7j5f7wOqRu6+KYVWPRpgHsYzxOavWkkiKv0XUvWeYWBIZFM4oy6A1WJqW2nEELcAjIeBX/0UWMig==",
-      "dev": true,
       "license": "GPL-2.0-or-later",
+      "peer": true,
       "dependencies": {
         "@ariakit/react": "^0.3.12",
         "@babel/runtime": "^7.16.0",
@@ -10216,8 +10186,8 @@
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.3.0.tgz",
       "integrity": "sha512-TtAYdKnqQ/L/nF0+fmlQ1wAvm90X9HRBrAuEMNmkzKhews/5GR0rR3dNSMjlf7C6mNdTO3mkYt6AQf9fvZFoiQ==",
-      "dev": true,
       "license": "GPL-2.0-or-later",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.16.0",
         "@types/mousetrap": "^1.6.8",
@@ -10245,8 +10215,8 @@
       "version": "10.3.0",
       "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.3.0.tgz",
       "integrity": "sha512-cImJw4k30coosH6QtiJllxEYr93w8981PPvhGhemMbRQ28MnSA7rbJPv3h2LO9oss5SQH1gU9kwNGAZcF6PMPg==",
-      "dev": true,
       "license": "GPL-2.0-or-later",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.16.0",
         "@wordpress/compose": "^7.3.0",
@@ -10276,8 +10246,8 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.3.0.tgz",
       "integrity": "sha512-vD0rLQxNlOoFd4n32HohhTif4P1JPW/Igjp0c/O2WZji+eXQM6P54fBu5veKvgwMmXpUn8y0xzgssj3pKAUgCg==",
-      "dev": true,
       "license": "GPL-2.0-or-later",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.16.0",
         "@wordpress/deprecated": "^4.3.0",
@@ -10310,8 +10280,8 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.3.0.tgz",
       "integrity": "sha512-K2GHXlwjx6GMhZjs52X1MXySCrqzh4IjoqF5IOcydMgWqOIE2++hMuB9Y55qN/Mhsrv/HO8Q1LaTxbEd6BuNJQ==",
-      "dev": true,
       "license": "GPL-2.0-or-later",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.16.0",
         "@wordpress/hooks": "^4.3.0"
@@ -10325,8 +10295,8 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.3.0.tgz",
       "integrity": "sha512-sf4h6jVqboRdhe3soyr5bt+Vpz24WG/AIMHm7pGaxfbV5jxx06ZZ8K1RKzhr7jF3wn7IgIc1wmMA+OFzEYqGyw==",
-      "dev": true,
       "license": "GPL-2.0-or-later",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.16.0",
         "@wordpress/deprecated": "^4.3.0"
@@ -10340,8 +10310,8 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.3.0.tgz",
       "integrity": "sha512-zuLLMIeJt1hZ95R4kdJFcsIaL2eud1kF40VCmwK3mK0qpgXv/1avtGX8lx6DMLL/GGL1yYcJhR13RSKSjxuGEQ==",
-      "dev": true,
       "license": "GPL-2.0-or-later",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.16.0"
       },
@@ -10376,8 +10346,8 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.3.0.tgz",
       "integrity": "sha512-DsiqzjuXqxJkLUoLomsGTFFxbSZgk+Lz+2/1yFH+BU3jQ6zeD64+JWv8Lt4+fKU154rV0KpfMwfD/oAC/Lp1zQ==",
-      "dev": true,
       "license": "GPL-2.0-or-later",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.16.0",
         "@types/react": "^18.2.79",
@@ -10481,8 +10451,8 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.3.0.tgz",
       "integrity": "sha512-Wu/Fq96E28UGnIO5VQW/aEgCiHWvzrD8izDnP8U0WZSuwIPYcS5iYmRe2UWc7rwyoeY2YXNd6xFjgd7oTOKNCA==",
-      "dev": true,
       "license": "GPL-2.0-or-later",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.16.0"
       },
@@ -10808,8 +10778,8 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.3.0.tgz",
       "integrity": "sha512-bpqwSXGyxPfhuxESKoAtL4ofB3CazzvcwcucTZ0g9Pat3KNuBaloSrPBliqqNOiSLWNH3nmpkaRmv4u89EdKAw==",
-      "dev": true,
       "license": "GPL-2.0-or-later",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.16.0"
       },
@@ -10822,8 +10792,8 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.3.0.tgz",
       "integrity": "sha512-rJDf9KjCuUnFwIwmOdN4FcL7RJnDzPxIdvvMoWXkYd9GseEeRTsY6xIG+fGgVGgYe3HwXDYSFCWTF/x2M9Eerg==",
-      "dev": true,
       "license": "GPL-2.0-or-later",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.16.0"
       },
@@ -10836,8 +10806,8 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-5.3.0.tgz",
       "integrity": "sha512-edHKkdZb6jNpbn+LUPu2wo1mKyhT819WJ7kI8hmMcHq82rNwwbMfcGoB3oSaphTphWfhlgxIxLczKOAbWDKudw==",
-      "dev": true,
       "license": "GPL-2.0-or-later",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.16.0",
         "@wordpress/hooks": "^4.3.0",
@@ -10858,8 +10828,8 @@
       "version": "10.3.0",
       "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-10.3.0.tgz",
       "integrity": "sha512-d2jOFfLIAxPr+/Bzg7wnRDEDPogMpVefe4cHgIx9kXp/+7DG4KWNJm842qVithjs1wVgSzavzWbFrTtPEZ+Uhw==",
-      "dev": true,
       "license": "GPL-2.0-or-later",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.16.0",
         "@wordpress/element": "^6.3.0",
@@ -10874,8 +10844,8 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.3.0.tgz",
       "integrity": "sha512-sZ+fypqjYX0/DTAKsm1G9ND9Wn4d3Ju4lI7SLSmCKdUL5EPY3g/2LpKQKDqljh9m6Ex5NWp2XfU8UVXpkEfbMQ==",
-      "dev": true,
       "license": "GPL-2.0-or-later",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.16.0"
       },
@@ -10925,8 +10895,8 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.3.0.tgz",
       "integrity": "sha512-o+L110/Y9ufS2eWVG1gXFs6+jPsMNVZoGJCt4PLjMmVabke0iaYstFppUdtQiOEDbnnhX9MH3RRtqp2AoSnaRQ==",
-      "dev": true,
       "license": "GPL-2.0-or-later",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.16.0",
         "@wordpress/i18n": "^5.3.0"
@@ -10986,8 +10956,8 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.3.0.tgz",
       "integrity": "sha512-h7wb2Np3n5etOg3j38GN80NEA8NgNdsSF/JJcRhpRf8FQOJd1mnKzj6szVHeKv0G7bvBif0NTgdSUm5M6Nikfg==",
-      "dev": true,
       "license": "GPL-2.0-or-later",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.16.0",
         "@wordpress/element": "^6.3.0",
@@ -11002,8 +10972,8 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.3.0.tgz",
       "integrity": "sha512-H7dGei1mFqKlz7NLFOGGtVgaBsORRaXeXNwWLI5rE0pI3XfGYd+zxNrG5aBzHw4fPqsITsxecNSaacc9fjqgjQ==",
-      "dev": true,
       "license": "GPL-2.0-or-later",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.16.0",
         "requestidlecallback": "^0.3.0"
@@ -11017,8 +10987,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.3.0.tgz",
       "integrity": "sha512-IbtH8ZENAKixSoTBKbmJ2ZCIkxsxqAoWPBtvbNJG9rYdzSk+BExdy/5VGO6Pv5GcUElHT+8uV26W4XxBVNl4UQ==",
-      "dev": true,
       "license": "GPL-2.0-or-later",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.16.0"
       },
@@ -11031,8 +11001,8 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.3.0.tgz",
       "integrity": "sha512-5HGdW8PqIK5fTyg1yo6NL2x1LTxU9vBvgUan/bLxYLX0YNw4+gQUex3djE0dwXNgrdE4mvWvYTcccc+2L59hig==",
-      "dev": true,
       "license": "GPL-2.0-or-later",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.16.0",
         "is-plain-object": "^5.0.0",
@@ -11051,8 +11021,8 @@
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.3.0.tgz",
       "integrity": "sha512-iL7qEybPOwtMp8WXMQndzfvT2k647ZqIMTj0rji4h2QAp/KaEHyYaIF6YhuQ7v5bSQ/9IAAOy3KGhguIuxIt8A==",
-      "dev": true,
       "license": "GPL-2.0-or-later",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.16.0",
         "@wordpress/a11y": "^4.3.0",
@@ -11077,8 +11047,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@wordpress/router/-/router-1.3.0.tgz",
       "integrity": "sha512-NJGdPrxJWdP00Iv6sFBdNS5ZuPbC76gxpiS75BWYeEr9Wd2MxiF4yVpIZUFkHdit7Hr9Rhah7HOsqp4T4qdIPg==",
-      "dev": true,
       "license": "GPL-2.0-or-later",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.16.0",
         "@wordpress/element": "^6.3.0",
@@ -11339,8 +11309,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.3.0.tgz",
       "integrity": "sha512-1XvU3GKpWeKFLCRx/3yEttRbIszD38vfH53XmCq2Y6IbWiyJLUGCnq4kiZjOaxA0o/DcAa4edscPyqmJj+wE+g==",
-      "dev": true,
       "license": "GPL-2.0-or-later",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.16.0",
         "@wordpress/is-shallow-equal": "^5.3.0"
@@ -11354,8 +11324,8 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.3.0.tgz",
       "integrity": "sha512-2rbpF2OD3rc/Jhmd4Mn9PxXTYGw63hIVMEJWzHs0x/mHmuDZEAn1vZcpDhJkksqtnHMS3BOlTv+Kbk1klxOpCg==",
-      "dev": true,
       "license": "GPL-2.0-or-later",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.16.0",
         "remove-accents": "^0.5.0"
@@ -11369,7 +11339,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.3.0.tgz",
       "integrity": "sha512-n82aKCxuGRNwAtSLaycErJuhKgfOc+KtiljyQITPperMh9i8bH6I+JxtYiu+aLMaY5vrVLVb+/kCzKuWVQIKPA==",
-      "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -11822,7 +11791,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^1.9.0"
@@ -11835,7 +11803,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "1.1.3"
@@ -11845,7 +11812,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/anymatch": {
@@ -12481,8 +12447,8 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
       "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "cosmiconfig": "^7.0.0",
@@ -13057,7 +13023,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -13067,7 +13032,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
       "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pascal-case": "^3.1.2",
@@ -13174,7 +13138,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/capital-case/-/capital-case-1.0.4.tgz",
       "integrity": "sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "no-case": "^3.0.4",
@@ -13216,7 +13179,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^3.2.1",
@@ -13231,7 +13193,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
@@ -13241,7 +13202,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
       "integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "camel-case": "^4.1.2",
@@ -13647,8 +13607,8 @@
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.11.tgz",
       "integrity": "sha512-C+0bbOqkezLIsmWSvlsXS0Q0bmkugu7jcfMIACB+RDEntIzQIkdr148we28AfSloQLRdZlYL/QYyrq05j/3Faw==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "good-listener": "^1.2.2",
         "select": "^1.1.2",
@@ -13772,8 +13732,8 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
       "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -13834,7 +13794,6 @@
       "version": "2.9.3",
       "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
       "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/colorette": {
@@ -13993,8 +13952,8 @@
       "version": "1.0.20",
       "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.20.tgz",
       "integrity": "sha512-UCB0ioiyj8CRjtrvaceBLqqhZCVP+1B8+NWQhmdsm0VXOJtobBCf1dBQmebCCo34qZmUwZfIH2MZLqNHazrfjg==",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/computeds": {
       "version": "0.0.1",
@@ -14115,7 +14074,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
       "integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "no-case": "^3.0.4",
@@ -14308,7 +14266,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
       "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/parse-json": "^4.0.0",
@@ -14911,7 +14868,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cwd": {
@@ -15018,8 +14974,8 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
       "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -15052,7 +15008,6 @@
       "version": "4.3.5",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
       "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.1.2"
@@ -15245,7 +15200,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -15515,8 +15469,8 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
       "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -15766,7 +15720,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
       "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "no-case": "^3.0.4",
@@ -15803,8 +15756,8 @@
       "version": "6.1.12",
       "resolved": "https://registry.npmjs.org/downshift/-/downshift-6.1.12.tgz",
       "integrity": "sha512-7XB/iaSJVS4T8wGFT3WRXmSF1UlBHAA40DshZtkrIscIN+VC+Lh363skLxFTvJwtNgHxAMDGEHT4xsyQFWL+UA==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.14.8",
         "compute-scroll-into-view": "^1.0.17",
@@ -15888,8 +15841,8 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "iconv-lite": "^0.6.2"
       }
@@ -15898,8 +15851,8 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -15988,14 +15941,13 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/equivalent-key-map/-/equivalent-key-map-0.2.2.tgz",
       "integrity": "sha512-xvHeyCDbZzkpN4VHQj/n+j2lOwL0VWszG30X4cOrc9Y7Tuo2qCdZK/0AMod23Z5dCtNUbaju6p0rwOhHUk05ew==",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
@@ -16278,7 +16230,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -17809,7 +17760,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-diff": {
@@ -18203,8 +18153,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
       "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/find-up": {
       "version": "5.0.0",
@@ -18471,8 +18421,8 @@
       "version": "11.3.6",
       "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.3.6.tgz",
       "integrity": "sha512-olpX48qfoSIDjhw0RbolhOGBQmdMAXHHpSI0PFdTj5LeXChcf5F4ApShs0mQ6FPEPOj7dnEvSyB07UgRK5G9Jw==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       },
@@ -18601,7 +18551,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -18819,8 +18768,8 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.4.0.tgz",
       "integrity": "sha512-sedZYLHlHeBop/gZ1jdg59hlUEcpcZJofLq2JFwJT1zTqAU3l2wFv6IsuwFHGqbiT9DWzMUW4/em2+hspnmMMA==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "encoding": "^0.1.12",
         "safe-buffer": "^5.1.1"
@@ -18928,7 +18877,6 @@
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -18983,8 +18931,8 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
       "integrity": "sha512-goW1b+d9q/HIwbVYZzZ6SsTr4IgE+WA44A0GmPIQstuOrgsFcT7VEJ48nmr9GaRtNu0XTKacFLGnBPAM6Afouw==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "delegate": "^3.1.2"
       }
@@ -19039,7 +18987,7 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/gradient-parser/-/gradient-parser-0.1.5.tgz",
       "integrity": "sha512-+uPlcVbjrKOnTzvz0MjTj7BfACj8OmxIa1moIjJV7btvhUMSJk0D47RfDCgDrZE3dYMz9Cf5xKJwnrKLjUq0KQ==",
-      "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -19098,7 +19046,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -19231,7 +19178,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -19338,7 +19284,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
       "integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "capital-case": "^1.0.4",
@@ -19349,15 +19294,15 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/highlight-words-core/-/highlight-words-core-1.2.2.tgz",
       "integrity": "sha512-BXUKIkUuh6cmmxzi5OIbUJxrG8OAk2MqoL1DtO3Wo9D2faJg2ph5ntyuQeLqaHJmzER6H5tllCDA9ZnNe9BVGg==",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/history": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
       "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.7.6"
       }
@@ -19366,8 +19311,8 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
       "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "dev": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "react-is": "^16.7.0"
       }
@@ -19376,8 +19321,8 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/homedir-polyfill": {
       "version": "1.0.3",
@@ -19800,7 +19745,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
       "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
@@ -19817,7 +19761,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -20189,7 +20132,6 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-async-function": {
@@ -20291,7 +20233,6 @@
       "version": "2.14.0",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.14.0.tgz",
       "integrity": "sha512-a5dFJih5ZLYlRtDc0dZWP7RiKr6xIKzmn/oAYCDvdLThadVgyJwlaoQPmRtMSpz+rk0OGAgIu+TcM9HUF0fk1A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
@@ -20640,7 +20581,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
       "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -20657,8 +20597,8 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/is-reference": {
       "version": "1.2.1",
@@ -23334,7 +23274,6 @@
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
@@ -23354,7 +23293,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
@@ -23845,7 +23783,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/linkify-it": {
@@ -24065,7 +24002,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
       "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.3"
@@ -24612,8 +24548,8 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/memize/-/memize-2.1.0.tgz",
       "integrity": "sha512-yywVJy8ctVlN5lNPxsep5urnZ6TTclwPEyigM9M3Bi8vseJBOfqNrGWN/r8NzuIt3PovM323W04blJfGQfQSVg==",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/memoizerific": {
       "version": "1.11.3",
@@ -25661,8 +25597,8 @@
       "version": "2.30.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
       "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -25671,8 +25607,8 @@
       "version": "0.5.45",
       "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.45.tgz",
       "integrity": "sha512-HIWmqA86KcmCAhnMAN0wuDOARV/525R2+lOLotuGFzn4HO+FH+/645z2wx0Dt3iDv6/p61SIvKnDstISainhLQ==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "moment": "^2.29.4"
       },
@@ -25684,8 +25620,8 @@
       "version": "1.6.5",
       "resolved": "https://registry.npmjs.org/mousetrap/-/mousetrap-1.6.5.tgz",
       "integrity": "sha512-QNo4kEepaIBwiT8CDhP98umTetp+JNfQYBWvC1pc6/OAibuXtRcxZ58Qz8skvEHYvURne/7R8T5VoOI7rDsEUA==",
-      "dev": true,
-      "license": "Apache-2.0 WITH LLVM-exception"
+      "license": "Apache-2.0 WITH LLVM-exception",
+      "peer": true
     },
     "node_modules/mri": {
       "version": "1.2.0",
@@ -25711,7 +25647,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/muggle-string": {
@@ -25851,7 +25786,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
       "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "lower-case": "^2.0.2",
@@ -26565,7 +26499,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -27337,7 +27270,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
       "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dot-case": "^3.0.4",
@@ -27348,7 +27280,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
@@ -27395,7 +27326,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
       "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
@@ -27447,7 +27377,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
       "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "no-case": "^3.0.4",
@@ -27475,7 +27404,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
       "integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dot-case": "^3.0.4",
@@ -27523,7 +27451,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-scurry": {
@@ -27554,14 +27481,13 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
       "integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -27595,7 +27521,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
       "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -29458,7 +29383,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -29470,7 +29394,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/property-information": {
@@ -29837,8 +29760,8 @@
       "version": "6.9.17",
       "resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-6.9.17.tgz",
       "integrity": "sha512-OBqd1BwVXpEJJn/yYROG+CbeqIDBWIp6wathlpB0kzZWWZIY1gPTsgK2yJEui5hOvkCdC2mcexF2V3DZVfLq2g==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "react": "^16.13.1 || ^17.0.0 || ^18.0.0",
         "react-dom": "^16.13.1 || ^17.0.0 || ^18.0.0"
@@ -29860,7 +29783,6 @@
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.6.1.tgz",
       "integrity": "sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -29955,7 +29877,6 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-markdown": {
@@ -30248,8 +30169,8 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
       "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.9.2"
       }
@@ -30311,7 +30232,6 @@
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
       "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/regenerator-transform": {
@@ -30473,15 +30393,15 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/rememo/-/rememo-4.0.2.tgz",
       "integrity": "sha512-NVfSP9NstE3QPNs/TnegQY0vnJnstKQSpcrsI2kBTB3dB2PkdfKdTa+abbjMIDqpc63fE5LfjLgfMst0ULMFxQ==",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/remove-accents": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.5.0.tgz",
       "integrity": "sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/repeat-element": {
       "version": "1.1.4",
@@ -30507,8 +30427,8 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/requestidlecallback/-/requestidlecallback-0.3.0.tgz",
       "integrity": "sha512-TWHFkT7S9p7IxLC5A1hYmAYQx2Eb9w1skrXmQ+dS1URyvR8tenMLl4lHbqEOUnpEYxNKpkVMXUgknVpBZWXXfQ==",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -30551,7 +30471,6 @@
       "version": "1.22.8",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
       "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-core-module": "^2.13.0",
@@ -31912,8 +31831,8 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/rungen/-/rungen-0.3.2.tgz",
       "integrity": "sha512-zWl10xu2D7zoR8zSC2U6bg5bYF6T/Wk7rxwp8IPaJH7f0Ge21G03kNHVgHR7tyVkSSfAOG0Rqf/Cl38JftSmtw==",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/rxjs": {
       "version": "6.6.7",
@@ -31958,7 +31877,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -32014,7 +31932,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/sass": {
@@ -32160,8 +32077,8 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
       "integrity": "sha512-OwpTSOfy6xSs1+pwcNrv0RBMOzI39Lp3qQKUTPVVPRjCdNa5JH/oPRiqsesIskK8TVgmRiHwO4KXlV2Li9dANA==",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/select-hose": {
       "version": "2.0.0",
@@ -32260,7 +32177,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
       "integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "no-case": "^3.0.4",
@@ -32668,7 +32584,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
       "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dot-case": "^3.0.4",
@@ -32928,7 +32843,6 @@
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -33173,7 +33087,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/stable": {
@@ -34356,14 +34269,13 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
       "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^3.0.0"
@@ -34413,7 +34325,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -34563,8 +34474,8 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/tannin/-/tannin-1.2.0.tgz",
       "integrity": "sha512-U7GgX/RcSeUETbV7gYgoz8PD7Ni4y95pgIP/Z6ayI3CfhSujwKEBlGFTCRN+Aqnuyf4AN2yHL+L8x+TCGjb9uA==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tannin/plural-forms": "^1.1.0"
       }
@@ -35124,8 +35035,8 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
       "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
@@ -35187,7 +35098,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -35608,7 +35518,6 @@
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
       "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tsutils": {
@@ -36219,7 +36128,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
       "integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.3"
@@ -36229,7 +36137,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
       "integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.3"
@@ -36358,8 +36265,8 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/use-lilius/-/use-lilius-2.0.5.tgz",
       "integrity": "sha512-IbPjJe4T6B0zQV6ahftVtHvCAxi6RAuDpEcO8TmnHh4nBtx7JbGdpbgXWOUj/9YjrzEbdT/lW7JWcBVbX3MbrA==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "date-fns": "^3.6.0"
       },
@@ -36372,8 +36279,8 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.3.tgz",
       "integrity": "sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
@@ -36382,8 +36289,8 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz",
       "integrity": "sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
@@ -36443,7 +36350,6 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
       "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -37736,7 +37642,6 @@
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
       "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">= 6"

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,6 @@
         "nanoid": "^5.0.7",
         "postcss-preset-env": "^9.5.14",
         "prettier": "npm:wp-prettier@3.0.3",
-        "pretty-quick": "^4.0.0",
         "prompt-sync": "^4.2.0",
         "react-markdown": "^9.0.1",
         "redux-devtools-extension": "^2.13.9",
@@ -73,23 +72,17 @@
         "rollup-preserve-directives": "^1.1.1",
         "storybook": "^8.1.11",
         "tail": "^2.2.6",
-        "ts-loader": "^9.5.1",
-        "ts-node": "^10.9.2",
         "typescript": "^5.3.3",
         "vite": "^5.2.13",
         "vite-plugin-dts": "^4.0.0-beta.0",
         "webpack": "^5.91.0"
       },
       "peerDependencies": {
-        "@wordpress/api-fetch": "^7.0.0",
         "@wordpress/base-styles": "^5.0.0",
         "@wordpress/components": "^28.0.0",
         "@wordpress/data": "^10.0.0",
         "@wordpress/element": "^6.1.0",
-        "@wordpress/i18n": "^5.0.0",
         "@wordpress/icons": "^10.0.0",
-        "@wordpress/private-apis": "^1.0.0",
-        "@wordpress/router": "^1.0.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       }
@@ -2493,6 +2486,8 @@
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
       },
@@ -2506,6 +2501,8 @@
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -8589,28 +8586,36 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
       "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
       "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
       "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@types/argparse": {
       "version": "1.0.38",
@@ -10057,22 +10062,6 @@
         "npm": ">=8.19.2"
       }
     },
-    "node_modules/@wordpress/api-fetch": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.3.0.tgz",
-      "integrity": "sha512-VpHG+9cLRZG13V2t1+xXpwuHJCeqiOl0ent9qXzbe6am9DtKSJ3oxiNdZaHjs6tdgGNuN/mTowRi5ceYJZb83Q==",
-      "license": "GPL-2.0-or-later",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/i18n": "^5.3.0",
-        "@wordpress/url": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
     "node_modules/@wordpress/babel-preset-default": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.3.0.tgz",
@@ -11043,27 +11032,6 @@
         "react": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/router": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/router/-/router-1.3.0.tgz",
-      "integrity": "sha512-NJGdPrxJWdP00Iv6sFBdNS5ZuPbC76gxpiS75BWYeEr9Wd2MxiF4yVpIZUFkHdit7Hr9Rhah7HOsqp4T4qdIPg==",
-      "license": "GPL-2.0-or-later",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/private-apis": "^1.3.0",
-        "@wordpress/url": "^4.3.0",
-        "history": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
     "node_modules/@wordpress/scripts": {
       "version": "28.3.0",
       "resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-28.3.0.tgz",
@@ -11314,21 +11282,6 @@
       "dependencies": {
         "@babel/runtime": "^7.16.0",
         "@wordpress/is-shallow-equal": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/url": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.3.0.tgz",
-      "integrity": "sha512-2rbpF2OD3rc/Jhmd4Mn9PxXTYGw63hIVMEJWzHs0x/mHmuDZEAn1vZcpDhJkksqtnHMS3BOlTv+Kbk1klxOpCg==",
-      "license": "GPL-2.0-or-later",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "remove-accents": "^0.5.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -11843,7 +11796,9 @@
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/argparse": {
       "version": "1.0.10",
@@ -14361,7 +14316,9 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-fetch": {
       "version": "3.1.5",
@@ -15557,6 +15514,8 @@
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -19296,16 +19255,6 @@
       "integrity": "sha512-BXUKIkUuh6cmmxzi5OIbUJxrG8OAk2MqoL1DtO3Wo9D2faJg2ph5ntyuQeLqaHJmzER6H5tllCDA9ZnNe9BVGg==",
       "license": "MIT",
       "peer": true
-    },
-    "node_modules/history": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
-      "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.7.6"
-      }
     },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
@@ -24075,7 +24024,9 @@
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true,
+      "peer": true
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
@@ -25622,16 +25573,6 @@
       "integrity": "sha512-QNo4kEepaIBwiT8CDhP98umTetp+JNfQYBWvC1pc6/OAibuXtRcxZ58Qz8skvEHYvURne/7R8T5VoOI7rDsEUA==",
       "license": "Apache-2.0 WITH LLVM-exception",
       "peer": true
-    },
-    "node_modules/mri": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
-      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/mrmime": {
       "version": "2.0.0",
@@ -29255,44 +29196,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/pretty-quick": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/pretty-quick/-/pretty-quick-4.0.0.tgz",
-      "integrity": "sha512-M+2MmeufXb/M7Xw3Afh1gxcYpj+sK0AxEfnfF958ktFeAyi5MsKY5brymVURQLgPLV1QaF5P4pb2oFJ54H3yzQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "execa": "^5.1.1",
-        "find-up": "^5.0.0",
-        "ignore": "^5.3.0",
-        "mri": "^1.2.0",
-        "picocolors": "^1.0.0",
-        "picomatch": "^3.0.1",
-        "tslib": "^2.6.2"
-      },
-      "bin": {
-        "pretty-quick": "lib/cli.mjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "prettier": "^3.0.0"
-      }
-    },
-    "node_modules/pretty-quick/node_modules/picomatch": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-3.0.1.tgz",
-      "integrity": "sha512-I3EurrIQMlRc9IaAZnqRR044Phh2DXY+55o7uJ0V+hYZAcQYSuFWsc9q5PvyDHUSCe1Qxn/iBz+78s86zWnGag==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/process": {
@@ -35319,112 +35222,14 @@
         "node": ">=6.10"
       }
     },
-    "node_modules/ts-loader": {
-      "version": "9.5.1",
-      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.5.1.tgz",
-      "integrity": "sha512-rNH3sK9kGZcH9dYzC7CewQm4NtxJTjSEVRJ2DyBZR7f8/wcta+iV44UPCXc5+nzDzivKtlzV6c9P4e+oFhDLYg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.0",
-        "enhanced-resolve": "^5.0.0",
-        "micromatch": "^4.0.0",
-        "semver": "^7.3.4",
-        "source-map": "^0.7.4"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "typescript": "*",
-        "webpack": "^5.0.0"
-      }
-    },
-    "node_modules/ts-loader/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/ts-loader/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/ts-loader/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ts-loader/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/ts-loader/node_modules/source-map": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
-      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/ts-loader/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/ts-node": {
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -35469,6 +35274,8 @@
       "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -35482,6 +35289,8 @@
       "integrity": "sha512-MxXdReSRhGO7VlFe1bRG/oI7/mdLV9B9JJT0N8vZOhF7gFRR5l3M8W9G8JxmKV+JC5mGqJ0QvqfSOLsCPa4nUw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "acorn": "^8.11.0"
       },
@@ -36371,7 +36180,9 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
@@ -37693,6 +37504,8 @@
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }

--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
     "nanoid": "^5.0.7",
     "postcss-preset-env": "^9.5.14",
     "prettier": "npm:wp-prettier@3.0.3",
-    "pretty-quick": "^4.0.0",
     "prompt-sync": "^4.2.0",
     "react-markdown": "^9.0.1",
     "redux-devtools-extension": "^2.13.9",
@@ -111,8 +110,6 @@
     "rollup-preserve-directives": "^1.1.1",
     "storybook": "^8.1.11",
     "tail": "^2.2.6",
-    "ts-loader": "^9.5.1",
-    "ts-node": "^10.9.2",
     "typescript": "^5.3.3",
     "vite": "^5.2.13",
     "vite-plugin-dts": "^4.0.0-beta.0",
@@ -124,15 +121,11 @@
   "peerDependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "@wordpress/api-fetch": "^7.0.0",
     "@wordpress/base-styles": "^5.0.0",
     "@wordpress/components": "^28.0.0",
     "@wordpress/data": "^10.0.0",
     "@wordpress/element": "^6.1.0",
-    "@wordpress/i18n": "^5.0.0",
-    "@wordpress/icons": "^10.0.0",
-    "@wordpress/private-apis": "^1.0.0",
-    "@wordpress/router": "^1.0.0"
+    "@wordpress/icons": "^10.0.0"
   },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automattic/big-sky-agents",
-  "version": "1.1.38",
+  "version": "1.1.41",
   "description": "The Big Sky Agents SDK",
   "repository": {
     "type": "git",
@@ -77,18 +77,6 @@
     "@typescript-eslint/eslint-plugin": "^7.12.0",
     "@vitejs/plugin-react": "^4.3.0",
     "@vtaits/react-fake-browser-ui": "^1.0.0",
-    "@wordpress/api-fetch": "^7.0.0",
-    "@wordpress/base-styles": "^5.0.0",
-    "@wordpress/components": "^28.0.0",
-    "@wordpress/data": "^10.0.0",
-    "@wordpress/element": "^6.1.0",
-    "@wordpress/env": "^10.0.0",
-    "@wordpress/eslint-plugin": "^20.0.0",
-    "@wordpress/i18n": "^5.0.0",
-    "@wordpress/icons": "^10.0.0",
-    "@wordpress/prettier-config": "^4.0.0",
-    "@wordpress/private-apis": "^1.0.0",
-    "@wordpress/router": "^1.0.0",
     "@wordpress/scripts": "^28.0.0",
     "@yelo/rollup-node-external": "^1.0.1",
     "alias-hq": "^6.2.3",
@@ -114,7 +102,6 @@
     "prompt-sync": "^4.2.0",
     "react-markdown": "^9.0.1",
     "redux-devtools-extension": "^2.13.9",
-    "rememo": "^4.0.2",
     "rollup": "^4.18.0",
     "rollup-plugin-copy": "^3.5.0",
     "rollup-plugin-dts": "^6.1.1",
@@ -129,11 +116,23 @@
     "typescript": "^5.3.3",
     "vite": "^5.2.13",
     "vite-plugin-dts": "^4.0.0-beta.0",
-    "webpack": "^5.91.0"
+    "webpack": "^5.91.0",
+    "@wordpress/env": "^10.0.0",
+    "@wordpress/eslint-plugin": "^20.0.0",
+    "@wordpress/prettier-config": "^4.0.0"
   },
   "peerDependencies": {
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "@wordpress/api-fetch": "^7.0.0",
+    "@wordpress/base-styles": "^5.0.0",
+    "@wordpress/components": "^28.0.0",
+    "@wordpress/data": "^10.0.0",
+    "@wordpress/element": "^6.1.0",
+    "@wordpress/i18n": "^5.0.0",
+    "@wordpress/icons": "^10.0.0",
+    "@wordpress/private-apis": "^1.0.0",
+    "@wordpress/router": "^1.0.0"
   },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com"

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -65,7 +65,16 @@ export default [
 				],
 			} ),
 		],
-		external: [ 'react', 'react-dom', 'prop-types', 'PropTypes' ],
+		external: [
+			'react',
+			'react-dom',
+			'prop-types',
+			'PropTypes',
+			'@wordpress/components',
+			'@wordpress/element',
+			'@wordpress/data',
+			'@wordpress/icons',
+		],
 	},
 	{
 		input: 'src/eval.js',

--- a/src/components/all-in-one-demo-ui.stories.jsx
+++ b/src/components/all-in-one-demo-ui.stories.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from '@wordpress/element';
 
 import AllInOneDemoUI from './all-in-one-demo-ui.jsx';
 

--- a/src/components/ask-user.jsx
+++ b/src/components/ask-user.jsx
@@ -11,7 +11,7 @@ import {
 	__experimentalItemGroup as ItemGroup,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import MessageInput from './message-input.jsx';
 import AskUserTool from '../ai/tools/ask-user.js';
 import withToolCall from './with-tool-call.jsx';

--- a/src/components/assistants-demo-ui.jsx
+++ b/src/components/assistants-demo-ui.jsx
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from '@wordpress/element';
 import { Flex } from '@wordpress/components';
 
 /**

--- a/src/components/assistants-demo-ui.stories.jsx
+++ b/src/components/assistants-demo-ui.stories.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from '@wordpress/element';
 
 import AssistantsDemoUI from './assistants-demo-ui';
 

--- a/src/components/chat-demo-ui.jsx
+++ b/src/components/chat-demo-ui.jsx
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useCallback, useState } from 'react';
+import { useCallback, useState } from '@wordpress/element';
 import { Flex } from '@wordpress/components';
 
 /**

--- a/src/components/chat-demo-ui.stories.jsx
+++ b/src/components/chat-demo-ui.stories.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from '@wordpress/element';
 
 import ChatDemoUI from './chat-demo-ui';
 

--- a/src/components/chat-provider/index.js
+++ b/src/components/chat-provider/index.js
@@ -1,2 +1,2 @@
 export { default as ChatProvider, ChatConsumer } from './context.jsx';
-export { default as useChat } from './use-chat';
+export { default as useChat } from './use-chat.js';

--- a/src/components/confirm.jsx
+++ b/src/components/confirm.jsx
@@ -1,7 +1,7 @@
 import { Button, Card, CardBody, CardFooter } from '@wordpress/components';
 import MessageContent from './message-content.jsx';
 import { CONFIRM_TOOL_NAME } from '../ai/tools/confirm.js';
-import { useCallback } from 'react';
+import { useCallback } from '@wordpress/element';
 import withToolCall from './with-tool-call.jsx';
 
 function Confirm( { args, respond, onConfirm } ) {

--- a/src/components/confirm.stories.jsx
+++ b/src/components/confirm.stories.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from '@wordpress/element';
 import { fn } from '@storybook/test';
 
 import Confirm from './confirm';

--- a/src/components/message-input.jsx
+++ b/src/components/message-input.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import {
 	Button,
 	DropZone,

--- a/src/components/page-spec-preview.jsx
+++ b/src/components/page-spec-preview.jsx
@@ -7,7 +7,7 @@ import { FakeBrowser } from '@vtaits/react-fake-browser-ui';
  * WordPress dependencies
  */
 import { Card, CardBody } from '@wordpress/components';
-import { useEffect, useState } from 'react';
+import { useEffect, useState } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 // import {
 // 	BlockCanvas,

--- a/src/components/popup-controls.jsx
+++ b/src/components/popup-controls.jsx
@@ -3,7 +3,7 @@ import { close, settings } from '@wordpress/icons';
 import ChatModelControls from './chat-model-controls.jsx';
 import AgentControls from './agent-controls.jsx';
 import ToolCallControls from './tool-call-controls.jsx';
-import { useEffect, useState } from 'react';
+import { useEffect, useState } from '@wordpress/element';
 import './popup-controls.scss';
 
 const PopUpControls = ( { setApiKey } ) => {

--- a/src/components/single-assistant-demo-ui.stories.jsx
+++ b/src/components/single-assistant-demo-ui.stories.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from '@wordpress/element';
 
 import SingleAssistantDemoUI from './single-assistant-demo-ui';
 

--- a/src/components/site-spec-preview.jsx
+++ b/src/components/site-spec-preview.jsx
@@ -11,7 +11,7 @@ import {
 } from '@wordpress/components';
 import { store as siteSpecStore } from '../store/index.js';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useState } from 'react';
+import { useState } from '@wordpress/element';
 
 function CorrectableTextField( { disabled, label, value, onChange } ) {
 	const [ isEditing, setIsEditing ] = useState( false );

--- a/src/components/toolkits-provider/context.jsx
+++ b/src/components/toolkits-provider/context.jsx
@@ -2,7 +2,7 @@ import { dispatch, register } from '@wordpress/data';
 import { createContext } from '@wordpress/element';
 import { store as defaultToolkitsStore } from '../../store/index.js';
 import { createToolkitsStore } from '../../store/toolkits.js';
-import defaultToolkits from '../../ai/toolkits/default-toolkits';
+import defaultToolkits from '../../ai/toolkits/default-toolkits.js';
 import uuidv4 from '../../utils/uuid.js';
 
 defaultToolkits.forEach( ( toolkit ) => {

--- a/src/components/toolkits-provider/index.js
+++ b/src/components/toolkits-provider/index.js
@@ -1,3 +1,3 @@
 export { default as ToolkitsProvider, ToolkitsConsumer } from './context.jsx';
-export { default as useToolkits } from './use-toolkits';
-export { default as useToolkit } from './use-toolkit';
+export { default as useToolkits } from './use-toolkits.js';
+export { default as useToolkit } from './use-toolkit.js';

--- a/src/components/toolkits-provider/use-toolkits.js
+++ b/src/components/toolkits-provider/use-toolkits.js
@@ -7,8 +7,8 @@ import { useDispatch, useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import defaultToolkits from '../../ai/toolkits/default-toolkits';
-import useAgents from '../agents-provider/use-agents';
+import defaultToolkits from '../../ai/toolkits/default-toolkits.js';
+import useAgents from '../agents-provider/use-agents.js';
 
 /**
  * Internal dependencies
@@ -120,7 +120,7 @@ function resolveAgentTools( agent, context, toolkitTools ) {
 export default function useToolkits() {
 	const toolkitsStore = useContext( Context );
 	const { activeAgent } = useAgents();
-	const { registerToolkit, setCallbacks, setContext, setTools } =
+	const { registerToolkit, setCallbacks, setContext } =
 		useDispatch( toolkitsStore );
 	const { call, agentSay, userSay } = useChat();
 	const {
@@ -253,7 +253,6 @@ export default function useToolkits() {
 		registerToolkit,
 		setCallbacks,
 		setContext,
-		setTools,
 		registerDefaultToolkits,
 	};
 }

--- a/src/components/user-message-input.jsx
+++ b/src/components/user-message-input.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from '@wordpress/element';
 import MessageInput from './message-input.jsx';
 import useChat from './chat-provider/use-chat.js';
 

--- a/src/hooks/use-agents-toolkit.js
+++ b/src/hooks/use-agents-toolkit.js
@@ -6,20 +6,14 @@ import { useEffect } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import createSetAgentTool, {
-	SET_AGENT_TOOL_NAME,
-} from '../ai/tools/set-agent.js';
+import { SET_AGENT_TOOL_NAME } from '../ai/tools/set-agent.js';
 import useAgents from '../components/agents-provider/use-agents.js';
 import useToolkits from '../components/toolkits-provider/use-toolkits.js';
 import AgentsToolkit from '../ai/toolkits/agents-toolkit.js';
 
 const useAgentsToolkit = () => {
 	const { agents, activeAgent, setActiveAgent } = useAgents();
-	const { setTools, setCallbacks, setContext } = useToolkits();
-
-	useEffect( () => {
-		setTools( AgentsToolkit.name, [ createSetAgentTool( agents ) ] );
-	}, [ agents, setTools ] );
+	const { setCallbacks, setContext } = useToolkits();
 
 	useEffect( () => {
 		setCallbacks( AgentsToolkit.name, {

--- a/src/hooks/use-analyze-site-toolkit.js
+++ b/src/hooks/use-analyze-site-toolkit.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useEffect } from 'react';
+import { useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies

--- a/src/hooks/use-chat-icon.js
+++ b/src/hooks/use-chat-icon.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { useRive, useStateMachineInput } from '@rive-app/react-canvas';
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies

--- a/src/hooks/use-chat-icon.stories.jsx
+++ b/src/hooks/use-chat-icon.stories.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from '@wordpress/element';
 
 import useChatIcon from './use-chat-icon.js';
 

--- a/src/hooks/use-chat-model.js
+++ b/src/hooks/use-chat-model.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useEffect, useState } from 'react';
+import { useEffect, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies

--- a/src/hooks/use-chat-settings.js
+++ b/src/hooks/use-chat-settings.js
@@ -1,5 +1,5 @@
 import { useEffect } from '@wordpress/element';
-import useChat from '../components/chat-provider/use-chat';
+import useChat from '../components/chat-provider/use-chat.js';
 import useAgents from '../components/agents-provider/use-agents.js';
 
 const useChatSettings = ( options ) => {

--- a/src/store/toolkits.js
+++ b/src/store/toolkits.js
@@ -28,13 +28,6 @@ export const actions = {
 			context,
 		};
 	},
-	setTools: ( name, tools ) => {
-		return {
-			type: 'REGISTER_TOOLKIT_TOOLS',
-			name,
-			tools,
-		};
-	},
 };
 
 const registerToolkit = ( state, action ) => {


### PR DESCRIPTION
Removes `setTools(toolkitSlug, tools)` from `useToolkits` because it makes evaluation harder. 

Best practice is to make any dynamic "tools" depend only on what's in the context. This makes it easier to mock environments.

The also replaces uses of `import { Foo } from 'react'` with `import { Foo } from '@wordpress/element'`