### PR TITLE
Add html eval output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ llama.log
 models/*
 !models/*.yaml
 stats.html
+eval.html

--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ node src/eval-agents.js --name test --agent ./src/ai/agents/weather-agent/v1.js 
 
 Right now it runs a trivial example, which you can find in [name-example.json](./eval/name-example.json).
 
+For more information on the `eval-agents.js` command, [read the docs](./docs/eval-agents-command.md).
+
 For more information on the example formats, see [Eval Dataset](./docs/eval-dataset.md) and [Eval Output](./docs/eval-output.md) documentation.
 
 ## LocalAI

--- a/docs/eval-agents-command.md
+++ b/docs/eval-agents-command.md
@@ -1,0 +1,101 @@
+# `eval-agents` Command Documentation
+
+## Overview
+
+The `eval-agents` command is a Node.js script that evaluates one or more AI agents against a specified dataset. It uses various AI models and services to perform the evaluation and generates a detailed report of the results.
+
+## Prerequisites
+
+- Node.js (version 14 or later for ESM support)
+- Required npm packages: `yargs`, `dotenv`, `open` (install using `npm install yargs dotenv open`)
+
+## Usage
+
+```bash
+node src/eval-agents.js [options]
+```
+
+Or, in the consumer package:
+
+```bash
+node_modules/.bin/eval-agents [options]
+```
+
+## Options
+
+| Option | Alias | Type | Description | Default |
+|--------|-------|------|-------------|---------|
+| --name | -n | string | Name of the evaluation | "Evaluation" |
+| --dataset | -d | string | Path to the dataset file | (Required) |
+| --apiKey | -k | string | API key for the service | process.env.OPENAI_API_KEY |
+| --temperature | -t | number | Temperature for the model | 0.1 |
+| --maxTokens | -m | number | Maximum tokens for the model | 2000 |
+| --model | -o | string | Model type to use | GPT_4O_MINI |
+| --service | -s | string | Service to use | OPENAI |
+| --agent | -a | array | Paths to agent JavaScript files | (Required) |
+| --json | -j | boolean | Output in JSON format | false |
+| --help | -h | | Show help | |
+
+## Environment Variables
+
+The script uses `dotenv` to load environment variables. You can set the following variable in a `.env` file:
+
+- `OPENAI_API_KEY`: Your OpenAI API key (used as default if --apiKey is not provided)
+
+## Input
+
+### Dataset File
+
+The `--dataset` option should point to a JSON file containing the evaluation dataset. The structure of this file should match the expected input format for the `loadDataset` function.
+
+### Agent Files
+
+The `--agent` option accepts one or more paths to JavaScript files that export agent objects. These files should have a default export that represents the agent to be evaluated.
+
+## Output
+
+By default, the script generates an HTML report (`eval.html`) and opens it in the default web browser. It also opens the URL specified in the `reportUrl` field of the evaluation results.
+
+If the `--json` flag is used, the script outputs the raw JSON results to the console instead of generating an HTML report.
+
+## Evaluation Process
+
+1. The script loads the specified dataset and agent(s).
+2. It runs the evaluation using the `runEvaluation` function, which is imported from `./eval.js`.
+3. The evaluation is performed using the specified model, service, and parameters.
+4. Results are collected for each agent and example in the dataset.
+
+## HTML Report
+
+The generated HTML report includes:
+
+- Overall evaluation results for each agent
+- Tables showing individual example results
+- Summary results for each agent
+- Comparative results between agents
+- Links to detailed reports
+
+## Examples
+
+1. Evaluate a single agent using default settings:
+   ```
+   ./eval-agents.js -d path/to/dataset.json -a path/to/agent.js
+   ```
+
+2. Evaluate multiple agents with custom settings:
+   ```
+   ./eval-agents.js -n "Custom Evaluation" -d path/to/dataset.json -a agent1.js agent2.js -t 0.5 -m 1000 -o GPT_4 -s ANTHROPIC -k your-api-key
+   ```
+
+3. Output results in JSON format:
+   ```
+   ./eval-agents.js -d path/to/dataset.json -a path/to/agent.js --json > results.json
+   ```
+
+## Notes
+
+- The script uses the `ChatModelService` and `ChatModelType` enums to specify the service and model. Make sure these are properly defined in the imported `./ai/chat-model.js` file.
+- The `runEvaluation` function is expected to return a result object with `evaluationResults` and `comparativeResult` properties.
+- The script sorts the example results by `exampleId` when generating the HTML report.
+
+For more information on the Big Sky Agents library and its components, refer to the project documentation or source code.

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,7 @@
         "mini-css-extract-plugin": "^2.9.0",
         "minimist": "^1.2.8",
         "nanoid": "^5.0.7",
+        "open": "^10.1.0",
         "postcss-preset-env": "^9.5.14",
         "prettier": "npm:wp-prettier@3.0.3",
         "prompt-sync": "^4.2.0",
@@ -11612,6 +11613,23 @@
         "node": "*"
       }
     },
+    "node_modules/alias-hq/node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
@@ -12835,6 +12853,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -15075,6 +15109,36 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/default-browser": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.2.1.tgz",
+      "integrity": "sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.0.tgz",
+      "integrity": "sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/default-gateway": {
@@ -20298,6 +20362,41 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container/node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-interactive": {
@@ -26635,17 +26734,48 @@
       }
     },
     "node_modules/open": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
-      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.1.0.tgz",
+      "integrity": "sha512-mnkeQ1qP5Ue2wd+aivTD3NHd/lZ96Lu0jgf0pwktLPtx6cTZiH7tyeGRRHs0zX0rbrahXPnXlUnbeXyaBBuIaw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "is-docker": "^2.0.0",
-        "is-wsl": "^2.1.1"
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "is-wsl": "^3.1.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open/node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open/node_modules/is-wsl": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
+      "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -31634,6 +31764,19 @@
       "dependencies": {
         "babel-runtime": "~6.25.0",
         "rtlcss": "^3.5.0"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.0.0.tgz",
+      "integrity": "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/run-async": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@automattic/big-sky-agents",
-  "version": "1.1.58",
+  "version": "1.1.59",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@automattic/big-sky-agents",
-      "version": "1.1.58",
+      "version": "1.1.59",
       "license": "GPL-2.0-or-later",
       "bin": {
         "agent-cli": "dist/agent-cli.js",

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "mini-css-extract-plugin": "^2.9.0",
     "minimist": "^1.2.8",
     "nanoid": "^5.0.7",
+    "open": "^10.1.0",
     "postcss-preset-env": "^9.5.14",
     "prettier": "npm:wp-prettier@3.0.3",
     "prompt-sync": "^4.2.0",
@@ -115,13 +116,13 @@
     "rollup-plugin-sass": "^1.12.22",
     "rollup-plugin-visualizer": "^5.12.0",
     "rollup-preserve-directives": "^1.1.1",
+    "sort-keys-recursive": "^2.1.10",
     "storybook": "^8.2.7",
     "tail": "^2.2.6",
     "typescript": "^5.3.3",
     "vite": "^5.2.13",
     "vite-plugin-dts": "^4.0.0-beta.0",
-    "webpack": "^5.91.0",
-    "sort-keys-recursive": "^2.1.10"
+    "webpack": "^5.91.0"
   },
   "peerDependencies": {
     "@wordpress/base-styles": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automattic/big-sky-agents",
-  "version": "1.1.58",
+  "version": "1.1.59",
   "description": "The Big Sky Agents SDK",
   "repository": {
     "type": "git",

--- a/src/eval-agents.js
+++ b/src/eval-agents.js
@@ -267,6 +267,7 @@ const writeHTMLReport = async ( evaluationOutput ) => {
 	await fs.writeFile( 'eval.html', html );
 	console.log( 'Report generated: eval.html' );
 	await open( 'eval.html' );
+	await open( evaluationOutput.reportUrl );
 };
 
 if ( ! argv.json ) {


### PR DESCRIPTION
Adds a HTML output by default for eval reports and opens the report and langsmith in browser tabs

![_Users_daniel_workspace_a8c_big-sky-agents_eval html](https://github.com/user-attachments/assets/24360a98-02f7-4728-a7b4-5b55f32a1411)
