### PR TITLE
Opt-in to structured output

### DIFF
--- a/src/ai/utils/openai.js
+++ b/src/ai/utils/openai.js
@@ -8,7 +8,6 @@ export const toOpenAITool = ( tool ) => {
 			},
 		},
 		required: [ 'value' ],
-		additionalProperties: ! tool.strict,
 	};
 
 	// enable structured output if strict is true

--- a/src/ai/utils/openai.js
+++ b/src/ai/utils/openai.js
@@ -1,17 +1,25 @@
-export const toOpenAITool = ( tool ) => ( {
-	type: 'function',
-	function: {
-		name: tool.name,
-		description: tool.description,
-		// default to a single string parameter called "value"
-		parameters: tool.parameters ?? {
-			type: 'object',
-			properties: {
-				value: {
-					type: 'string',
-				},
+export const toOpenAITool = ( tool ) => {
+	// default to a single string parameter called "value"
+	const parameters = tool.parameters ?? {
+		type: 'object',
+		properties: {
+			value: {
+				type: 'string',
 			},
-			required: [ 'value' ],
 		},
-	},
-} );
+		required: [ 'value' ],
+		additionalProperties: ! tool.strict,
+	};
+
+	// enable structured output if strict is true
+	parameters.additionalProperties = ! tool.strict;
+	return {
+		type: 'function',
+		function: {
+			name: tool.name,
+			description: tool.description,
+			parameters,
+		},
+		strict: !! tool.strict,
+	};
+};


### PR DESCRIPTION
Allow a tool to opt into structured output

Example:
```
const createUpsertSocialLinkTool = ( services = [] ) => {
	return {
		name: 'upsert_social_link',
		description: `Call this if the user asks to add or update a social link. The url must be provided by the user. The service must be in the provided list of supported services.`,
		parameters: {
			type: 'object',
			properties: {
				service: {
					type: 'string',
					description: `The requested service of the social link.`,
					enum: services,
				},
				url: {
					type: 'string',
					description: `The URL of the social link.`,
				},
			},
			required: [ 'service', 'url' ],
		},
		strict: true,
	};
};
```