### PR TITLE
Allow clients to turn off streaming

### DIFF
--- a/src/hooks/use-chat-settings.js
+++ b/src/hooks/use-chat-settings.js
@@ -43,7 +43,7 @@ const useChatSettings = ( options ) => {
 
 	// if chat.stream !== stream, set it
 	useEffect( () => {
-		if ( options.stream && options.stream !== stream ) {
+		if ( options.stream !== undefined && options.stream !== stream ) {
 			setStream( options.stream );
 		}
 	}, [ options, stream, setStream ] );


### PR DESCRIPTION
Bug that prevented turning off streaming with:

```
	useChatSettings( {
		...
		stream: false,
	} );
```

See Big Sky PR 1755 for more context on how to text