### PR TITLE
Various fixes for OpenAI assistants

### DIFF
--- a/src/ai/utils/openai.js
+++ b/src/ai/utils/openai.js
@@ -22,3 +22,10 @@ export const toOpenAITool = ( tool ) => {
 		strict: !! tool.strict,
 	};
 };
+
+export const toAssistantOpenAITool = ( tool ) => {
+	const openAITool = toOpenAITool( tool );
+	// remove "strict" prop
+	delete openAITool.strict;
+	return openAITool;
+};

--- a/src/components/assistants-demo-ui.jsx
+++ b/src/components/assistants-demo-ui.jsx
@@ -43,15 +43,17 @@ import withImplicitOauth from '../hooks/with-implicit-oauth.jsx';
  * @param {string}                root0.apiKey          The token to use for the chat model.
  * @param {Function}              root0.onApiKeyChanged Callback function to call when the token changes.
  * @param {AssistantModelService} root0.service         The service to use for the assistant model.
+ * @param {boolean}               root0.stream          Whether to stream the assistant model.
  *                                                      -->
  */
-const AssistantsDemoUI = ( { apiKey, onApiKeyChanged, service } ) => {
+const AssistantsDemoUI = ( { apiKey, onApiKeyChanged, service, stream } ) => {
 	const [ selectedPageId, setSelectedPageId ] = useState( null );
 
 	useChatSettings( {
 		apiKey,
 		feature: 'big-sky',
 		assistantEnabled: true,
+		stream: stream ?? false,
 		service: service ?? AssistantModelService.OPENAI,
 		model: AssistantModelType.GPT_4O_MINI,
 		initialAgentId: WAPUU_AGENT_ID,

--- a/src/components/chat-with-gutenberg/direct-standard.stories.jsx
+++ b/src/components/chat-with-gutenberg/direct-standard.stories.jsx
@@ -1,7 +1,7 @@
 import ChatWithGutenberg from './index.jsx';
 
 export default {
-	title: 'Features/Gutenberg/Direct',
+	title: 'Features/Gutenberg/Direct/Standard',
 	component: ChatWithGutenberg,
 	argTypes: {
 		apiKey: {
@@ -23,6 +23,7 @@ const Template = ( args ) => <ChatWithGutenberg { ...args } />;
 export const ChatWithArtifactsDemo = Template.bind( {} );
 
 ChatWithArtifactsDemo.args = {
+	stream: false,
 	apiKey: import.meta.env.STORYBOOK_LANGCHAIN_API_KEY,
 	baseUrl: import.meta.env.STORYBOOK_LANGGRAPH_CLOUD_BASE_URL,
 };

--- a/src/components/chat-with-gutenberg/direct-stream.stories.jsx
+++ b/src/components/chat-with-gutenberg/direct-stream.stories.jsx
@@ -1,8 +1,8 @@
-import { WPCOMChatWithGutenberg } from './index.jsx';
+import ChatWithGutenberg from './index.jsx';
 
 export default {
-	title: 'Features/Gutenberg/WPCOM',
-	component: WPCOMChatWithGutenberg,
+	title: 'Features/Gutenberg/Direct/Stream',
+	component: ChatWithGutenberg,
 	argTypes: {
 		apiKey: {
 			control: 'text',
@@ -18,14 +18,12 @@ export default {
 	],
 };
 
-const Template = ( args ) => <WPCOMChatWithGutenberg { ...args } />;
+const Template = ( args ) => <ChatWithGutenberg { ...args } />;
 
 export const ChatWithArtifactsDemo = Template.bind( {} );
 
 ChatWithArtifactsDemo.args = {
+	stream: true,
 	apiKey: import.meta.env.STORYBOOK_LANGCHAIN_API_KEY,
 	baseUrl: import.meta.env.STORYBOOK_LANGGRAPH_CLOUD_BASE_URL,
-	wpcomClientId: import.meta.env.STORYBOOK_WPCOM_CLIENT_ID,
-	wpcomOauthToken: import.meta.env.STORYBOOK_WPCOM_ACCESS_TOKEN,
-	redirectUri: import.meta.env.STORYBOOK_WPCOM_REDIRECT_URI,
 };

--- a/src/components/chat-with-gutenberg/index.jsx
+++ b/src/components/chat-with-gutenberg/index.jsx
@@ -52,6 +52,7 @@ const GraphAgent = {
  * @param {boolean}  root0.stream          Whether to stream the response from the assistant.
  * @param {string}   root0.wpcomOauthToken The WP.com OAuth token.
  * @param {Function} root0.onApiKeyChanged Callback function to call when the token changes.
+ *                                         -->
  */
 const ChatWithGutenberg = ( {
 	baseUrl,

--- a/src/components/chat-with-gutenberg/index.jsx
+++ b/src/components/chat-with-gutenberg/index.jsx
@@ -49,9 +49,9 @@ const GraphAgent = {
  * @param {string}   root0.baseUrl         The base URL for the LangGraph Cloud API.
  * @param {string}   root0.apiKey          The token to use for the chat model.
  * @param {Object}   root0.user            The user object.
+ * @param {boolean}  root0.stream          Whether to stream the response from the assistant.
  * @param {string}   root0.wpcomOauthToken The WP.com OAuth token.
  * @param {Function} root0.onApiKeyChanged Callback function to call when the token changes.
- *                                         -->
  */
 const ChatWithGutenberg = ( {
 	baseUrl,
@@ -59,6 +59,7 @@ const ChatWithGutenberg = ( {
 	onApiKeyChanged,
 	user,
 	wpcomOauthToken,
+	stream,
 } ) => {
 	const [ selectedArtifactId, setSelectedArtifactId ] = useState( null );
 
@@ -71,6 +72,7 @@ const ChatWithGutenberg = ( {
 		baseUrl,
 		initialAgentId: GraphAgent.id,
 		autoCreateAssistant: true,
+		stream: stream ?? false,
 		graphConfig: {
 			user_id: user?.ID,
 			user_name: user?.display_name,

--- a/src/components/chat-with-gutenberg/wpcom-standard.stories.jsx
+++ b/src/components/chat-with-gutenberg/wpcom-standard.stories.jsx
@@ -1,0 +1,32 @@
+import { WPCOMChatWithGutenberg } from './index.jsx';
+
+export default {
+	title: 'Features/Gutenberg/WPCOM/Standard',
+	component: WPCOMChatWithGutenberg,
+	argTypes: {
+		apiKey: {
+			control: 'text',
+			name: 'OAuth API Key',
+		},
+	},
+	decorators: [
+		( Story ) => (
+			<div style={ { minHeight: '600px' } }>
+				<Story />
+			</div>
+		),
+	],
+};
+
+const Template = ( args ) => <WPCOMChatWithGutenberg { ...args } />;
+
+export const ChatWithArtifactsDemo = Template.bind( {} );
+
+ChatWithArtifactsDemo.args = {
+	stream: false,
+	apiKey: import.meta.env.STORYBOOK_LANGCHAIN_API_KEY,
+	baseUrl: import.meta.env.STORYBOOK_LANGGRAPH_CLOUD_BASE_URL,
+	wpcomClientId: import.meta.env.STORYBOOK_WPCOM_CLIENT_ID,
+	wpcomOauthToken: import.meta.env.STORYBOOK_WPCOM_ACCESS_TOKEN,
+	redirectUri: import.meta.env.STORYBOOK_WPCOM_REDIRECT_URI,
+};

--- a/src/components/chat-with-gutenberg/wpcom-stream.stories.jsx
+++ b/src/components/chat-with-gutenberg/wpcom-stream.stories.jsx
@@ -1,0 +1,32 @@
+import { WPCOMChatWithGutenberg } from './index.jsx';
+
+export default {
+	title: 'Features/Gutenberg/WPCOM/Stream',
+	component: WPCOMChatWithGutenberg,
+	argTypes: {
+		apiKey: {
+			control: 'text',
+			name: 'OAuth API Key',
+		},
+	},
+	decorators: [
+		( Story ) => (
+			<div style={ { minHeight: '600px' } }>
+				<Story />
+			</div>
+		),
+	],
+};
+
+const Template = ( args ) => <WPCOMChatWithGutenberg { ...args } />;
+
+export const ChatWithArtifactsDemo = Template.bind( {} );
+
+ChatWithArtifactsDemo.args = {
+	stream: true,
+	apiKey: import.meta.env.STORYBOOK_LANGCHAIN_API_KEY,
+	baseUrl: import.meta.env.STORYBOOK_LANGGRAPH_CLOUD_BASE_URL,
+	wpcomClientId: import.meta.env.STORYBOOK_WPCOM_CLIENT_ID,
+	wpcomOauthToken: import.meta.env.STORYBOOK_WPCOM_ACCESS_TOKEN,
+	redirectUri: import.meta.env.STORYBOOK_WPCOM_REDIRECT_URI,
+};

--- a/src/hooks/use-agent-executor.js
+++ b/src/hooks/use-agent-executor.js
@@ -9,7 +9,7 @@ import { useEffect, useMemo, useState } from '@wordpress/element';
 import useAgents from '../components/agents-provider/use-agents.js';
 import useChat from '../components/chat-provider/use-chat.js';
 import useToolkits from '../components/toolkits-provider/use-toolkits.js';
-import { toOpenAITool } from '../ai/utils/openai.js';
+import { toAssistantOpenAITool, toOpenAITool } from '../ai/utils/openai.js';
 
 const useAgentExecutor = () => {
 	const { activeAgent, started, setAgentStarted } = useAgents();
@@ -327,17 +327,10 @@ const useAgentExecutor = () => {
 			isThreadRunComplete &&
 			isThreadDataLoaded &&
 			! isAwaitingUserInput &&
-			additionalMessages.length > 0 &&
-			messages.length > 0
+			( additionalMessages.length > 0 || pendingToolCalls.length > 0 )
 		) {
-			console.warn( '🧠 creating thread run', {
-				instructions,
-				additionalInstructions,
-				additionalMessages,
-				messages,
-			} );
 			// deduplicate and convert to OpenAI format
-			const openAITools = tools.map( toOpenAITool );
+			const openAITools = tools.map( toAssistantOpenAITool );
 			createThreadRun( {
 				tools: openAITools,
 				instructions,
@@ -351,7 +344,6 @@ const useAgentExecutor = () => {
 		isAssistantAvailable,
 		additionalInstructions,
 		additionalMessages,
-		messages.length,
 		instructions,
 		isAwaitingUserInput,
 		isThreadRunComplete,
@@ -359,6 +351,7 @@ const useAgentExecutor = () => {
 		tools,
 		isThreadDataLoaded,
 		messages,
+		pendingToolCalls,
 	] );
 
 	/**

--- a/src/hooks/use-agent-executor.js
+++ b/src/hooks/use-agent-executor.js
@@ -330,6 +330,12 @@ const useAgentExecutor = () => {
 			additionalMessages.length > 0 &&
 			messages.length > 0
 		) {
+			console.warn( '🧠 creating thread run', {
+				instructions,
+				additionalInstructions,
+				additionalMessages,
+				messages,
+			} );
 			// deduplicate and convert to OpenAI format
 			const openAITools = tools.map( toOpenAITool );
 			createThreadRun( {

--- a/src/store/chat.js
+++ b/src/store/chat.js
@@ -12,6 +12,7 @@ export const THREAD_RUN_ACTIVE_STATUSES = [
 	'requires_action',
 	'cancelling',
 	'completed',
+	'success', // langgraph cloud
 ];
 
 export const THREAD_RUN_EXPIRED_STATUSES = [
@@ -41,6 +42,7 @@ export const THREAD_RUN_COMPLETED_STATUSES = [
 	// 'cancelled',
 	// 'failed',
 	'completed',
+	'success', // langgraph cloud
 ];
 
 const initialState = {
@@ -901,7 +903,10 @@ const addMessageReducer = ( state, message ) => {
 		);
 
 		if ( existingToolCallResultMessage ) {
-			console.warn( 'tool call result already exists', message );
+			console.warn( 'tool call result already exists', {
+				message,
+				existingToolCallResultMessage,
+			} );
 			return state;
 		}
 	}
@@ -1372,6 +1377,7 @@ export const reducer = ( state = initialState, action ) => {
 		case 'GET_THREAD_RUNS_BEGIN_REQUEST':
 			return { ...state, isFetchingThreadRuns: true };
 		case 'GET_THREAD_RUNS_END_REQUEST':
+			console.warn( '🧠 GET_THREAD_RUNS_END_REQUEST', action );
 			const threadsRequiringAction = action.threadRuns.filter(
 				( tr ) =>
 					tr.status === 'requires_action' &&
@@ -1534,7 +1540,7 @@ export const selectors = {
 	isThreadRunInProgress: ( state ) => {
 		return (
 			state.threadId &&
-			[ 'queued', 'in_progress' ].includes(
+			THREAD_RUN_RUNNING_STATUSES.includes(
 				selectors.getActiveThreadRunStatus( state )
 			)
 		);


### PR DESCRIPTION
Not a complete fix, but a cleanup. Non-streaming responses still don't work for langgraph cloud or assistants (but I think streaming responses are far better anyway). Streaming responses for Assistants have some weird issues too.

- migrate assistants to use event source parser
- remove old commented code
- filter unsupported params from Assistant v2 tool descriptions
- clean up demos
