### PR TITLE
Bump version to 1.1.79

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automattic/big-sky-agents",
-  "version": "1.1.77",
+  "version": "1.1.79",
   "description": "The Big Sky Agents SDK",
   "repository": {
     "type": "git",


### PR DESCRIPTION
It looks like I'm skipping a version in the diff. But the current registered [version on npmjs](https://www.npmjs.com/package/@automattic/big-sky-agents) is 1.1.78. 