### PR TITLE
Introduce the 'store' parameter for storing the conversation on the openai end

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@automattic/big-sky-agents",
-  "version": "1.1.77",
+  "version": "1.1.82",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@automattic/big-sky-agents",
-      "version": "1.1.77",
+      "version": "1.1.82",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "eventsource-parser": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automattic/big-sky-agents",
-  "version": "1.1.81",
+  "version": "1.1.82",
   "description": "The Big Sky Agents SDK",
   "repository": {
     "type": "git",

--- a/src/ai/chat-model.js
+++ b/src/ai/chat-model.js
@@ -251,6 +251,7 @@ class ChatModel {
 	 * @param {Array<string>} params.tags                   The tags to use for analytics
 	 * @param {Function}      params.middleware             The middleware to use
 	 * @param {string}        params.sessionId              The session ID
+	 * @param {boolean}       params.store                  Whether to store the conversation for debugging in OpenAI dashboard for evaluation: https://platform.openai.com/docs/guides/evals
 	 * @return {Promise<Object>} The response message
 	 */
 	async run( {
@@ -264,6 +265,7 @@ class ChatModel {
 		tags,
 		middleware,
 		sessionId,
+		store,
 	} ) {
 		if ( ! messages || ! messages.length ) {
 			throw new Error( 'Missing history' );
@@ -293,6 +295,7 @@ class ChatModel {
 			messages,
 			tools,
 			sessionId,
+			store,
 		} );
 
 		const choice = response.choices[ 0 ];
@@ -621,6 +624,11 @@ export class WPCOMJetpackAIChatModel extends ChatModel {
 
 		if ( this.sessionId ) {
 			params.session_id = this.sessionId;
+		}
+
+		// Store is a parameter to tell OpenAI to store the conversation for debugging in OpenAI dashboard for evaluation: https://platform.openai.com/docs/guides/evals
+		if ( request.store ) {
+			params.store = request.store;
 		}
 
 		return params;

--- a/src/components/chat-provider/use-chat.js
+++ b/src/components/chat-provider/use-chat.js
@@ -80,6 +80,7 @@ export default function useChat() {
 		setStream,
 		setGraphConfig,
 		setError,
+		setStoreConversation,
 	} = useDispatch( agentStore );
 
 	const {
@@ -118,6 +119,7 @@ export default function useChat() {
 		feature,
 		stream,
 		graphConfig,
+		isStoringConversation,
 	} = useSelect( ( select ) => ( {
 		baseUrl: select( agentStore ).getBaseUrl(),
 		autoCreateAssistant: select( agentStore ).isAutoCreateAssistant(),
@@ -155,6 +157,7 @@ export default function useChat() {
 		feature: select( agentStore ).getFeature(),
 		stream: select( agentStore ).getStream(),
 		graphConfig: select( agentStore ).getGraphConfig(),
+		isStoringConversation: select( agentStore ).isStoringConversation(),
 	} ) );
 
 	return {
@@ -248,5 +251,7 @@ export default function useChat() {
 		isThreadDataLoaded,
 		additionalMessages,
 		reset,
+		isStoringConversation,
+		setStoreConversation,
 	};
 }

--- a/src/hooks/use-chat-settings.js
+++ b/src/hooks/use-chat-settings.js
@@ -128,7 +128,6 @@ const useChatSettings = ( options ) => {
 			options.store !== undefined &&
 			options.store !== isStoringConversation
 		) {
-			console.log( 'store', options.store );
 			setStoreConversation( options.store );
 		}
 	}, [ isStoringConversation, options.store, setStoreConversation ] );

--- a/src/hooks/use-chat-settings.js
+++ b/src/hooks/use-chat-settings.js
@@ -26,6 +26,8 @@ const useChatSettings = ( options ) => {
 		setStream,
 		setGraphConfig,
 		graphConfig,
+		isStoringConversation,
+		setStoreConversation,
 	} = useChat();
 	const { activeAgentId, setActiveAgent } = useAgents();
 
@@ -120,6 +122,16 @@ const useChatSettings = ( options ) => {
 			setSessionId( options.sessionId );
 		}
 	}, [ sessionId, options.sessionId, setSessionId ] );
+
+	useEffect( () => {
+		if (
+			options.store !== undefined &&
+			options.store !== isStoringConversation
+		) {
+			console.log( 'store', options.store );
+			setStoreConversation( options.store );
+		}
+	}, [ isStoringConversation, options.store, setStoreConversation ] );
 };
 
 export default useChatSettings;

--- a/src/store/chat.js
+++ b/src/store/chat.js
@@ -94,6 +94,8 @@ const initialState = {
 	isCreatingThreadMessage: false,
 	isFetchingThreadMessages: false,
 	isSubmittingToolOutputs: false,
+	// Store is a parameter to tell OpenAI to store the conversation for debugging in OpenAI dashboard for evaluation: https://platform.openai.com/docs/guides/evals
+	store: false,
 };
 
 /**
@@ -246,6 +248,7 @@ const runChatCompletion =
 			messages,
 			feature,
 			response_format,
+			store,
 		} = select( ( state ) => {
 			return {
 				model: state.root.model,
@@ -254,6 +257,7 @@ const runChatCompletion =
 				feature: state.root.feature,
 				stream: state.root.stream,
 				response_format: state.root.response_format || '',
+				store: state.root.store,
 			};
 		} );
 
@@ -284,6 +288,7 @@ const runChatCompletion =
 					model,
 					temperature,
 					feature,
+					store,
 					// graphConfig,
 				} );
 				const message = {
@@ -377,6 +382,7 @@ const runChatCompletion =
 				temperature,
 				feature,
 				response_format,
+				store,
 			} );
 			dispatch( actions.addMessage( assistantMessage ) );
 			dispatch( { type: 'CHAT_END_REQUEST' } );
@@ -1076,6 +1082,8 @@ export const reducer = ( state = initialState, action ) => {
 			return { ...state, model: action.model };
 		case 'SET_TEMPERATURE':
 			return { ...state, temperature: action.temperature };
+		case 'SET_STORE_CONVERSATION':
+			return { ...state, store: action.store };
 
 		// Chat Completion
 		case 'CHAT_BEGIN_REQUEST':
@@ -1657,6 +1665,7 @@ export const selectors = {
 	getAssistantId: ( state ) => state.assistantId ?? state.defaultAssistantId,
 	getGraphConfig: ( state ) => state.graphConfig,
 	getGraphId: ( state ) => state.graphId,
+	isStoringConversation: ( state ) => state.store,
 	updateThreadRuns: ( state ) => state.threadRun,
 	getThreadRunsUpdated: ( state ) => state.threadRunsUpdated,
 	getThreadMessagesUpdated: ( state ) => state.threadMessagesUpdated,
@@ -1798,6 +1807,10 @@ export const actions = {
 	setModel: ( model ) => ( {
 		type: 'SET_MODEL',
 		model,
+	} ),
+	setStoreConversation: ( store ) => ( {
+		type: 'SET_STORE_CONVERSATION',
+		store,
 	} ),
 	clearError,
 	setToolResult,


### PR DESCRIPTION
This is a change necessitated by the arbitrary architecture of this package.
We want to pipe the `store` parameter to OpenAI API from the app, so we have to punch a hole through layers and layers of abstraction.

This introduces that parameter so it's available via Redux store in the app that uses this package.

## Testing instructions

1. Apply this branch
2. Check out and apply  https://github.com/Automattic/big-sky-plugin/pull/2004 for big-sky
3. `nvm use stable` inside this package
4. `npm link` inside here
5. `npm install`
6. `npm run dev` - **make sure it's building**
7. Go to your big sky directory
8. `nvm use stable`
9. `npm install`
10. `npm link @automattic/big-sky-agents`
11. `npm run dev` - **make sure it's building**
12. Open the built big sky
13. Open the console (ctrl+d)
14. You should see a toggle
15. Toggle the toggle
16. Make a request
17. Inspect the call to `jetpack-ai-query` to see if it's setting to `store:true` parameter

<img width="503" alt="Zrzut ekranu 2024-10-31 o 14 29 49" src="https://github.com/user-attachments/assets/53c8dbe7-7046-4e28-9512-5a6c336d26d9">


<img width="570" alt="Zrzut ekranu 2024-10-31 o 14 32 37" src="https://github.com/user-attachments/assets/103bee1e-2689-4e88-bd41-598fa3ee8584">



