### PR TITLE
Fix strict mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@automattic/big-sky-agents",
-  "version": "1.1.82",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@automattic/big-sky-agents",
-      "version": "1.1.82",
+      "version": "1.2.1",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "eventsource-parser": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automattic/big-sky-agents",
-  "version": "1.1.82",
+  "version": "1.2.1",
   "description": "The Big Sky Agents SDK",
   "repository": {
     "type": "git",

--- a/src/ai/utils/openai.js
+++ b/src/ai/utils/openai.js
@@ -16,10 +16,10 @@ export const toOpenAITool = ( tool ) => {
 		type: 'function',
 		function: {
 			name: tool.name,
+			strict: !! tool.strict,
 			description: tool.description,
 			parameters,
 		},
-		strict: !! tool.strict,
 	};
 };
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/big-sky-plugin/issues/2015. It makes function calling more reliable across every single function call, and makes the function calls conform to enums.

## WHAT?

We were passing `strict` parameter in the wrong nesting level, see more investigation in https://github.com/Automattic/big-sky-plugin/issues/2015. Basically we were telling the model "these structured outputs? Yeah don't worry about them, just make it kinda similar-ish."

That is because according to OpenAI docs the `strict` parameter should be nested in the same level as function name and we were not doing that.
From OpenAI docs:

<img width="694" alt="Zrzut ekranu 2024-11-1 o 13 11 48" src="https://github.com/user-attachments/assets/cc27015a-b743-48b5-9faf-4079abc93f71">


### Testing instructions

- Apply this branch
- Check out and apply https://github.com/Automattic/big-sky-plugin/pull/2016 for big-sky
- nvm use stable here
- npm link inside here
- npm install
- npm run dev - make sure it's building
- Go to your big sky directory
- nvm use stable
- npm install
- npm link @automattic/big-sky-agents
- npm run dev - make sure it's building
- Open the built big sky
- Make a request like "Give me a flirtatious font"
- Observe the function call not have the `flirtatious` keyword, but only keys from enum.
- experiment with similar approaches to make the model produce an unreliable function call
